### PR TITLE
feat: Railway deployment (Nixpacks, single-origin, staging+prod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, production]
+  push:
+    branches: [main, production]
+
+# Dedupe stale runs on the same branch — only the latest push/PR push
+# is built, older runs are cancelled automatically.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Build & test
+    runs-on: ubuntu-latest
+
+    # NODE_AUTH_TOKEN must be available at job level (not step level) so
+    # that actions/setup-node can restore the npm cache with `.npmrc`
+    # substitution resolved in the same environment.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Run test suite
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,12 @@ packages/*/package-lock.json
 .env
 .env.local
 .env.*.local
-.npmrc
+
+# Cursor — local AI rules, not part of the product
+.cursor/
+
+# Local-only overrides (e.g. vendored design-system stub without GitHub Packages access)
+vendor/
 
 # IDE
 .vscode/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@czechcanoe:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,0 +1,37 @@
+# GitHub Packages authentication for @czechcanoe/rvp-design-system
+#
+# The committed .npmrc at the repo root declares the scope registry and
+# references `NODE_AUTH_TOKEN` via variable expansion. You need to provide
+# the token in your shell environment — do NOT put a literal token in this
+# file or in the committed .npmrc.
+#
+# How to get a token:
+#   1. GitHub → Settings → Developer settings → Personal access tokens
+#   2. Create a "classic" token with scope `read:packages`
+#      (or a fine-grained token with Packages: Read)
+#   3. If your organization enforces SSO, click "Configure SSO" on the token
+#      and authorize it for the `CzechCanoe` organization.
+#
+# How to use the token:
+#
+#   Option A — ad-hoc shell export (per session):
+#     bash/zsh:   export NODE_AUTH_TOKEN=ghp_yourTokenHere
+#     PowerShell: $env:NODE_AUTH_TOKEN = "ghp_yourTokenHere"
+#     cmd.exe:    set NODE_AUTH_TOKEN=ghp_yourTokenHere
+#
+#   Option B — persist in your user-level ~/.npmrc (recommended):
+#     Add the line (replace token):
+#       //npm.pkg.github.com/:_authToken=ghp_yourTokenHere
+#     Then npm ci will pick it up without any shell environment.
+#     On Windows the file lives at %USERPROFILE%\.npmrc
+#
+# CI/CD and Railway builds:
+#   - GitHub Actions: add the token as a repository secret named
+#     `NODE_AUTH_TOKEN` (Settings → Secrets and variables → Actions).
+#   - Railway: add `NODE_AUTH_TOKEN` as a project variable, marked for the
+#     build phase.
+#
+# Verification:
+#   After setting the token, running `npm ci` at the repo root should pull
+#   `@czechcanoe/rvp-design-system` successfully. If you get an opaque 401,
+#   the token is missing or does not have SSO authorization.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ flowchart LR
 | Database | SQLite + Kysely |
 | Frontend | React + Vite |
 | Design System | [rvp-design-system](https://github.com/CzechCanoe/rvp-design-system/) |
-| Deployment | Railway (planned) |
+| Deployment | Railway (Nixpacks, single-origin) |
 
 ## Project Structure
 
@@ -61,6 +61,7 @@ c123-live-mini/
 
 - Node.js 20.x or higher
 - npm 10.x or higher
+- **GitHub Packages access:** the client depends on `@czechcanoe/rvp-design-system` published to GitHub Packages. Before running `npm install`, set `NODE_AUTH_TOKEN` in your environment — see [`.npmrc.example`](.npmrc.example) for step-by-step instructions.
 
 ## Development
 
@@ -86,11 +87,98 @@ npm test
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `3000` | Server port |
-| `DATABASE_PATH` | `./data/live-mini.db` | SQLite database path |
-| `MASTER_PASSWORDS` | *(empty)* | Comma-separated admin passwords. If not set, admin API is open. |
+| Variable | Default | Scope | Description |
+|----------|---------|-------|-------------|
+| `NODE_ENV` | *(empty)* | runtime | Set to `production` to enable single-origin SPA serving and admin safety checks. |
+| `PORT` | `3000` | runtime | Server port. Railway injects this automatically. |
+| `DATABASE_PATH` | `./data/live-mini.db` | runtime | SQLite database path. **For Railway, set this to a path on the mounted volume, e.g. `/data/live-mini.db`** — otherwise data is lost on redeploy. |
+| `MASTER_PASSWORDS` | *(empty)* | runtime | Comma-separated admin passwords. Required in production unless `ADMIN_OPEN=1` is set for bootstrap. |
+| `ADMIN_OPEN` | *(empty)* | runtime | Set to `1` to temporarily allow open admin API in production (for initial Railway bootstrap). Always set `MASTER_PASSWORDS` as soon as the first event is created. |
+| `CLIENT_DIST_PATH` | *(auto)* | runtime | Override for the client SPA dist directory. Defaults to `packages/client/dist` relative to the server package. |
+| `LOG_LEVEL` | `info` | runtime | Fastify logger level. |
+| `NODE_AUTH_TOKEN` | *(empty)* | build | GitHub Packages token with `read:packages`. Required at install/build time (locally, CI, Railway build). Not used at runtime. |
+
+## Deployment
+
+c123-live-mini deploys to [Railway](https://railway.app/) as a single Nixpacks-built Node.js service. The Fastify server serves API, WebSocket, and the client SPA from the same origin — see [Architecture → Production Deployment Model](docs/ARCHITECTURE.md#production-deployment-model).
+
+### Local production smoke test
+
+Before pushing anything to Railway, verify the production path works locally:
+
+```bash
+npm run build
+NODE_ENV=production MASTER_PASSWORDS=test PORT=3000 \
+  node packages/server/dist/index.js
+```
+
+Then in another terminal:
+
+```bash
+curl http://localhost:3000/health                  # {"status":"ok"}
+curl -I http://localhost:3000/                      # 200, text/html
+curl http://localhost:3000/api/v1/events            # {"events":[]}
+curl -I http://localhost:3000/api/v1/nonexistent    # 404, application/json
+```
+
+### Railway auto-deploy flow
+
+The project uses **two Railway environments within one Railway project**, each watching a different GitHub branch:
+
+| Environment | Watched branch | Purpose |
+|-------------|----------------|---------|
+| `staging` | `main` | Auto-deploys on every merge to `main`. For integration testing and dev feedback. |
+| `production` | `production` | Auto-deploys on every merge to the `production` branch. Release via PR `main → production`. |
+
+Both environments use their own Railway Volume mounted at `/data` and their own set of environment variables (different `MASTER_PASSWORDS`, same `NODE_AUTH_TOKEN`). See issue [#117](https://github.com/OpenCanoeTiming/c123-live-mini/issues/117) for the step-by-step Railway setup checklist.
+
+### First-time admin bootstrap
+
+Because the server refuses to start in `NODE_ENV=production` with an empty `MASTER_PASSWORDS`, the very first deploy uses a bootstrap flow:
+
+1. In Railway, set `ADMIN_OPEN=1` **instead of** `MASTER_PASSWORDS` on the first deploy. The server starts with loud warnings in the log.
+2. Create the first event via the admin API (no `X-Master-Key` header needed yet):
+   ```bash
+   curl -X POST https://<your-service>/api/v1/admin/events \
+     -H "Content-Type: application/json" \
+     -d '{"eventId":"bootstrap","mainTitle":"Bootstrap"}'
+   ```
+   The response contains an `apiKey` used for data ingestion.
+3. In Railway, remove `ADMIN_OPEN` and set `MASTER_PASSWORDS=<strong password>`. Redeploy — the server now starts silently with admin endpoints protected.
+4. Verify: `curl -X POST https://<your-service>/api/v1/admin/events` should return `401 Unauthorized`, and the same call with `-H "X-Master-Key: <password>"` should succeed.
+
+### Cost strategy
+
+Railway pricing (pay-as-you-go, 2026):
+
+| Plan | Monthly fee | Included credit | Volume limit |
+|------|-------------|-----------------|--------------|
+| **Free** | $0 | $1 usage credit | 0.5 GB per service |
+| **Hobby** | $5 | $5 usage credit | 5 GB per service |
+
+This project is designed to run on **Free plan with Serverless sleep** between races. Expected usage pattern:
+
+- Idle between races (both services sleeping): ~$0.10–0.15/month
+- Race weekend (12-hour race day, ~200 concurrent spectators): ~$0.80
+- 6 races per year: ~$7/year total — well within Free credit
+
+**Upgrade to Hobby manually 1–2 days before each race** as a safety margin against mid-race shutdowns if the Free credit is close to exhaustion, then downgrade back to Free after the race. Estimated total cost: **~$10–25/year** depending on number of races and actual sleep reliability.
+
+If Serverless sleep proves unreliable for WebSocket-heavy traffic, switch to permanent Hobby ($5/month flat, ~$60/year) for predictability.
+
+### Pause / resume between races
+
+Two options:
+
+1. **Keep Serverless mode on Free plan** — services sleep automatically after 10 minutes without outbound traffic. Nothing to do manually. Cold start on first request after sleep is ~5–10 seconds.
+2. **Manually stop services** in Railway UI between races. Volume persists, no compute billed. Manual redeploy required before the next race.
+
+### Troubleshooting
+
+- **First Railway build takes 5–10 minutes** — `npm ci` from a cold cache is slow, subsequent builds are much faster thanks to Nixpacks layer caching.
+- **`npm ci` fails with 401** — `NODE_AUTH_TOKEN` is missing or has no `read:packages` scope / no SSO authorization for `CzechCanoe` org.
+- **WebSocket drops after Serverless sleep** — expected for the first connection after a cold start. Clients should reconnect automatically (see `useEventWebSocket` hook).
+- **Server refuses to start with `[FATAL] NODE_ENV=production with no MASTER_PASSWORDS`** — the admin safety policy is doing its job. Set `MASTER_PASSWORDS` or, for bootstrap only, `ADMIN_OPEN=1`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ npm test
 | `NODE_ENV` | *(empty)* | runtime | Set to `production` to enable single-origin SPA serving and admin safety checks. |
 | `PORT` | `3000` | runtime | Server port. Railway injects this automatically. |
 | `DATABASE_PATH` | `./data/live-mini.db` | runtime | SQLite database path. **For Railway, set this to a path on the mounted volume, e.g. `/data/live-mini.db`** — otherwise data is lost on redeploy. |
-| `MASTER_PASSWORDS` | *(empty)* | runtime | Comma-separated admin passwords. Required in production unless `ADMIN_OPEN=1` is set for bootstrap. |
-| `ADMIN_OPEN` | *(empty)* | runtime | Set to `1` to temporarily allow open admin API in production (for initial Railway bootstrap). Always set `MASTER_PASSWORDS` as soon as the first event is created. |
+| `MASTER_PASSWORDS` | *(empty)* | runtime | Comma-separated admin passwords. **Required in production** — the server refuses to start in `NODE_ENV=production` without it. |
 | `CLIENT_DIST_PATH` | *(auto)* | runtime | Override for the client SPA dist directory. Defaults to `packages/client/dist` relative to the server package. |
 | `LOG_LEVEL` | `info` | runtime | Fastify logger level. |
 | `NODE_AUTH_TOKEN` | *(empty)* | build | GitHub Packages token with `read:packages`. Required at install/build time (locally, CI, Railway build). Not used at runtime. |
@@ -132,20 +131,21 @@ The project uses **two Railway environments within one Railway project**, each w
 
 Both environments use their own Railway Volume mounted at `/data` and their own set of environment variables (different `MASTER_PASSWORDS`, same `NODE_AUTH_TOKEN`). See issue [#117](https://github.com/OpenCanoeTiming/c123-live-mini/issues/117) for the step-by-step Railway setup checklist.
 
-### First-time admin bootstrap
+### Admin setup
 
-Because the server refuses to start in `NODE_ENV=production` with an empty `MASTER_PASSWORDS`, the very first deploy uses a bootstrap flow:
+The server refuses to start in `NODE_ENV=production` with an empty `MASTER_PASSWORDS` — set it **before** the first deploy:
 
-1. In Railway, set `ADMIN_OPEN=1` **instead of** `MASTER_PASSWORDS` on the first deploy. The server starts with loud warnings in the log.
-2. Create the first event via the admin API (no `X-Master-Key` header needed yet):
+1. Generate a strong password locally (e.g. `openssl rand -base64 24`).
+2. In Railway, add `MASTER_PASSWORDS=<password>` to the environment variables.
+3. Deploy. Create the first event with the master key:
    ```bash
    curl -X POST https://<your-service>/api/v1/admin/events \
      -H "Content-Type: application/json" \
+     -H "X-Master-Key: <password>" \
      -d '{"eventId":"bootstrap","mainTitle":"Bootstrap"}'
    ```
-   The response contains an `apiKey` used for data ingestion.
-3. In Railway, remove `ADMIN_OPEN` and set `MASTER_PASSWORDS=<strong password>`. Redeploy — the server now starts silently with admin endpoints protected.
-4. Verify: `curl -X POST https://<your-service>/api/v1/admin/events` should return `401 Unauthorized`, and the same call with `-H "X-Master-Key: <password>"` should succeed.
+   The response contains an `apiKey` used for XML data ingestion from `c123-server`.
+4. Verify unauthenticated access is rejected: the same call without `X-Master-Key` must return `401 Unauthorized`.
 
 ### Cost strategy
 
@@ -178,7 +178,7 @@ Two options:
 - **First Railway build takes 5–10 minutes** — `npm ci` from a cold cache is slow, subsequent builds are much faster thanks to Nixpacks layer caching.
 - **`npm ci` fails with 401** — `NODE_AUTH_TOKEN` is missing or has no `read:packages` scope / no SSO authorization for `CzechCanoe` org.
 - **WebSocket drops after Serverless sleep** — expected for the first connection after a cold start. Clients should reconnect automatically (see `useEventWebSocket` hook).
-- **Server refuses to start with `[FATAL] NODE_ENV=production with no MASTER_PASSWORDS`** — the admin safety policy is doing its job. Set `MASTER_PASSWORDS` or, for bootstrap only, `ADMIN_OPEN=1`.
+- **Server refuses to start with `[FATAL] NODE_ENV=production requires MASTER_PASSWORDS`** — the admin safety policy is doing its job. Set `MASTER_PASSWORDS=<strong password>` in Railway and redeploy.
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,6 +208,64 @@ This follows the Live Page Prototype from rvp-design-system as the reference imp
 
 ---
 
+## Production Deployment Model
+
+In production, c123-live-mini runs as a **single Fastify process** that serves the REST API, the WebSocket endpoint, and the client SPA from the same origin. This is different from the development setup, where Vite's dev server runs separately on port 5173 and proxies `/api` to Fastify on port 3000.
+
+```mermaid
+flowchart LR
+    subgraph DEV[Development — two processes]
+        VITE[Vite dev :5173] -->|proxy /api + ws| FASTIFY_DEV[Fastify :3000]
+    end
+
+    subgraph PROD[Production — single origin]
+        CLIENT_PROD[Client browser] -->|HTTP + WS| FASTIFY_PROD[Fastify PORT]
+        FASTIFY_PROD --> STATIC[packages/client/dist<br/>SPA assets]
+        FASTIFY_PROD --> API[/api/v1/*/]
+        FASTIFY_PROD --> WS[/api/v1/events/:id/ws/]
+    end
+```
+
+### Why single-origin
+
+- **No CORS configuration needed** — client and server share the origin
+- **No separate WebSocket URL config** — client uses `window.location.host` dynamically
+- **One Railway service** — simpler deployment, one volume, one healthcheck, one billing line
+- **Simpler environment** — client uses relative paths (`/api/v1/...`), no env-based API base URL
+
+### Static file serving implementation
+
+Production SPA hosting is registered in `packages/server/src/registerProductionSpa.ts`. It's only active when `NODE_ENV=production`, and only when the client `dist` directory is resolvable (default: `packages/client/dist` relative to the server package; overridable via `CLIENT_DIST_PATH`).
+
+The registration happens inside a nested `app.register(async instance => ...)` plugin so cache headers and the 404 handler stay encapsulated from the API context. Three key configuration choices:
+
+1. **`wildcard: false`** on `@fastify/static` — the default catch-all `GET /*` handler would conflict with `/api/*` routes and `@fastify/websocket`'s upgrade interception.
+2. **`index: false`** — disables auto-serving `index.html` on `/`; the `setNotFoundHandler` handles it centrally so the SPA fallback logic is in one place.
+3. **`setNotFoundHandler`** in the nested scope — for unknown paths:
+   - If URL starts with `/api` or `/api/`, return **JSON 404** (so client-side API error handling is predictable).
+   - If method is not GET/HEAD, return JSON 404.
+   - Otherwise, serve `index.html` so the React Router / wouter router can handle the client-side route.
+
+Cache headers:
+
+- `index.html` → `no-store, max-age=0` (SPA shell should always be fresh)
+- Hashed assets (`index-X3H2G8hJ.js` etc.) → `public, max-age=31536000, immutable`
+
+### Admin API safety in production
+
+When `NODE_ENV=production`, the server **refuses to start** if `MASTER_PASSWORDS` is empty unless `ADMIN_OPEN=1` is explicitly set. This prevents accidentally deploying a public URL with an open admin endpoint. The `ADMIN_OPEN=1` path is intended only for the initial Railway bootstrap — it logs loud warnings on every start and should be removed as soon as the first event is created and `MASTER_PASSWORDS` is configured.
+
+### Dependencies between dev and prod modes
+
+The same Fastify app factory (`createApp` in `app.ts`) is used in both modes. The only difference is:
+
+- In dev, `registerProductionSpa` is a no-op (NODE_ENV check)
+- In prod, it registers the static + SPA fallback nested plugin at the end of route setup
+
+`createApp` remains **synchronous** — `registerProductionSpa` uses `app.register` which is fire-and-forget, so no async migration is needed in call sites. WebSocket routes and API routes are unchanged between dev and prod.
+
+---
+
 ## Integration Context
 
 This service is designed as a standalone component that will eventually integrate into a larger Czech Canoe Federation (CSK) registration portal system.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,7 +253,7 @@ Cache headers:
 
 ### Admin API safety in production
 
-When `NODE_ENV=production`, the server **refuses to start** if `MASTER_PASSWORDS` is empty unless `ADMIN_OPEN=1` is explicitly set. This prevents accidentally deploying a public URL with an open admin endpoint. The `ADMIN_OPEN=1` path is intended only for the initial Railway bootstrap — it logs loud warnings on every start and should be removed as soon as the first event is created and `MASTER_PASSWORDS` is configured.
+When `NODE_ENV=production`, the server **refuses to start** if `MASTER_PASSWORDS` is empty. This prevents accidentally deploying a public URL with an open admin endpoint — the master key must be configured before the first deploy. In development (`NODE_ENV` unset), an empty password list keeps the admin API open for local convenience.
 
 ### Dependencies between dev and prod modes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,16 +44,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@asamuzakjp/dom-selector": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
@@ -69,16 +59,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -798,6 +778,22 @@
         }
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.1.tgz",
+      "integrity": "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
@@ -909,6 +905,53 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@fastify/send": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz",
+      "integrity": "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-8.3.0.tgz",
+      "integrity": "sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^0.5.4",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^11.0.0"
+      }
+    },
     "node_modules/@fastify/websocket": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.2.0.tgz",
@@ -930,12 +973,30 @@
         "ws": "^8.16.0"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
@@ -2020,6 +2081,15 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2082,6 +2152,18 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -2214,6 +2296,18 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2232,6 +2326,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-tree": {
@@ -2305,6 +2413,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -2431,6 +2548,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -2679,6 +2802,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2729,6 +2868,30 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2750,6 +2913,26 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -2820,6 +3003,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2865,16 +3069,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/json-schema-ref-resolver": {
@@ -3232,6 +3426,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.563.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
@@ -3268,6 +3471,18 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -3290,6 +3505,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3297,6 +3527,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -3399,6 +3638,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -3425,6 +3670,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -3951,6 +4221,33 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -3970,6 +4267,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -4065,6 +4374,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -4284,6 +4602,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/totalist": {
@@ -4622,6 +4949,21 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4902,6 +5244,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@c123-live-mini/shared": "*",
+        "@fastify/static": "^8.3.0",
         "@fastify/websocket": "^11.2.0",
         "better-sqlite3": "^12.8.0",
         "fast-xml-parser": "^5.5.9",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "concurrently -n server,client -c blue,green \"npm run dev -w @c123-live-mini/server\" \"npm run dev -w @c123-live-mini/client\"",
+    "predev": "npm run build -w @c123-live-mini/shared",
+    "dev": "concurrently -n shared,server,client -c yellow,blue,green \"npm run build -w @c123-live-mini/shared -- --watch --preserveWatchOutput\" \"npm run dev -w @c123-live-mini/server\" \"npm run dev -w @c123-live-mini/client\"",
     "build": "npm run build -w @c123-live-mini/shared && npm run build -w @c123-live-mini/server && npm run build -w @c123-live-mini/client",
     "seed": "npm run seed -w @c123-live-mini/server",
     "test": "vitest run",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@c123-live-mini/shared": "*",
+    "@fastify/static": "^8.3.0",
     "@fastify/websocket": "^11.2.0",
     "better-sqlite3": "^12.8.0",
     "fast-xml-parser": "^5.5.9",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -11,6 +11,7 @@ import { registerOnCourseRoutes } from './routes/oncourse.js';
 import { registerCategoriesRoutes } from './routes/categories.js';
 import { registerConfigRoutes } from './routes/config.js';
 import { registerWebSocketRoutes } from './routes/websocket.js';
+import { registerProductionSpa } from './registerProductionSpa.js';
 import { AppError } from './utils/errors.js';
 import { WebSocketManager } from './services/WebSocketManager.js';
 
@@ -57,6 +58,12 @@ export function createApp(options: AppOptions): FastifyInstance {
   registerOnCourseRoutes(app, db);
   registerCategoriesRoutes(app, db);
   registerConfigRoutes(app, db);
+
+  // In production, serve the client SPA (index.html + hashed assets) from
+  // the Fastify process. No-op in development (Vite dev server serves the
+  // SPA). Must run AFTER all API + WS routes so the SPA fallback does not
+  // shadow real endpoints.
+  registerProductionSpa(app);
 
   // Global error handler following contracts/api.md error format
   app.setErrorHandler(

--- a/packages/server/src/clientDistPath.ts
+++ b/packages/server/src/clientDistPath.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Directory containing this server package root (works from both `src/` and
+ * compiled `dist/`, since the package layout is preserved).
+ */
+const SERVER_PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Default path to the client SPA build, relative to the monorepo layout:
+ * `packages/server/` is sibling to `packages/client/`, so the default
+ * resolves to `packages/client/dist`.
+ */
+export function defaultClientDistPath(): string {
+  return resolve(SERVER_PACKAGE_ROOT, '../client/dist');
+}
+
+/**
+ * Resolve the directory that holds the client SPA (index.html + assets).
+ * Honors `CLIENT_DIST_PATH` env var for custom deployment layouts, and falls
+ * back to the default monorepo path.
+ *
+ * Returns `null` if the resolved directory does not exist on disk — callers
+ * should treat this as "skip SPA static hosting" (e.g. dev mode, or missing
+ * build).
+ */
+export function resolveClientDistDir(): string | null {
+  const raw = process.env.CLIENT_DIST_PATH?.trim();
+  const dir = raw && raw.length > 0 ? resolve(raw) : defaultClientDistPath();
+  return existsSync(dir) ? dir : null;
+}

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -64,24 +64,6 @@ export function createDatabase(dbPath?: string): Kysely<Database> {
   return new Kysely<Database>({ dialect });
 }
 
-// Default database instance (legacy support)
-mkdirSync(dirname(DEFAULT_DATABASE_PATH), { recursive: true });
-const defaultSqliteDb = new SQLite(DEFAULT_DATABASE_PATH);
-defaultSqliteDb.pragma('foreign_keys = ON');
-const dialect = new SqliteDialect({
-  database: defaultSqliteDb,
-});
-
-export const db = new Kysely<Database>({ dialect });
-
-export function getDb(): Kysely<Database> {
-  return db;
-}
-
-export async function closeDb(): Promise<void> {
-  await db.destroy();
-}
-
 /**
  * Run database migrations
  *

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,6 +17,38 @@ const start = async () => {
       .map((p) => p.trim())
       .filter(Boolean);
 
+    // Admin API safety: refuse to start in production with open admin
+    // unless ADMIN_OPEN=1 is explicitly set. This prevents accidental
+    // deployment of a public URL with open master-key endpoints.
+    const isProd = process.env.NODE_ENV === 'production';
+    const adminOpen = process.env.ADMIN_OPEN === '1';
+    if (isProd && masterPasswords.length === 0 && !adminOpen) {
+      console.error(
+        '[FATAL] NODE_ENV=production with no MASTER_PASSWORDS and no ADMIN_OPEN=1'
+      );
+      console.error(
+        '[FATAL] Refusing to start with open admin API in production.'
+      );
+      console.error(
+        '[FATAL] Either set MASTER_PASSWORDS=<comma-separated> to secure admin,'
+      );
+      console.error(
+        '[FATAL] or set ADMIN_OPEN=1 to explicitly allow open admin (bootstrap only).'
+      );
+      process.exit(1);
+    }
+    if (isProd && masterPasswords.length === 0 && adminOpen) {
+      console.warn(
+        '[WARNING] Running in production with open admin API (ADMIN_OPEN=1).'
+      );
+      console.warn(
+        '[WARNING] This is a security risk — intended only for bootstrap.'
+      );
+      console.warn(
+        '[WARNING] Set MASTER_PASSWORDS and unset ADMIN_OPEN as soon as possible.'
+      );
+    }
+
     // Create and configure app
     const app = createApp({ db, logger: true, masterPasswords });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,36 +17,17 @@ const start = async () => {
       .map((p) => p.trim())
       .filter(Boolean);
 
-    // Admin API safety: refuse to start in production with open admin
-    // unless ADMIN_OPEN=1 is explicitly set. This prevents accidental
-    // deployment of a public URL with open master-key endpoints.
-    const isProd = process.env.NODE_ENV === 'production';
-    const adminOpen = process.env.ADMIN_OPEN === '1';
-    if (isProd && masterPasswords.length === 0 && !adminOpen) {
+    // Admin API safety: in production, MASTER_PASSWORDS is mandatory.
+    // Refuse to start with an empty password list to prevent accidentally
+    // deploying a public URL with an open admin API.
+    if (process.env.NODE_ENV === 'production' && masterPasswords.length === 0) {
       console.error(
-        '[FATAL] NODE_ENV=production with no MASTER_PASSWORDS and no ADMIN_OPEN=1'
+        '[FATAL] NODE_ENV=production requires MASTER_PASSWORDS to be set.'
       );
       console.error(
         '[FATAL] Refusing to start with open admin API in production.'
       );
-      console.error(
-        '[FATAL] Either set MASTER_PASSWORDS=<comma-separated> to secure admin,'
-      );
-      console.error(
-        '[FATAL] or set ADMIN_OPEN=1 to explicitly allow open admin (bootstrap only).'
-      );
       process.exit(1);
-    }
-    if (isProd && masterPasswords.length === 0 && adminOpen) {
-      console.warn(
-        '[WARNING] Running in production with open admin API (ADMIN_OPEN=1).'
-      );
-      console.warn(
-        '[WARNING] This is a security risk — intended only for bootstrap.'
-      );
-      console.warn(
-        '[WARNING] Set MASTER_PASSWORDS and unset ADMIN_OPEN as soon as possible.'
-      );
     }
 
     // Create and configure app

--- a/packages/server/src/registerProductionSpa.ts
+++ b/packages/server/src/registerProductionSpa.ts
@@ -1,0 +1,97 @@
+import { basename } from 'node:path';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import fastifyStatic from '@fastify/static';
+import { resolveClientDistDir } from './clientDistPath.js';
+
+/**
+ * Returns the URL path without query string.
+ */
+function pathnameOnly(url: string): string {
+  const q = url.indexOf('?');
+  return q === -1 ? url : url.slice(0, q);
+}
+
+/**
+ * Exact-match test for the API mount point. Returns true for `/api` and
+ * `/api/*`, but NOT for lookalikes such as `/api.js` — those should fall
+ * through to the SPA static handler.
+ */
+function isApiRequestPath(url: string): boolean {
+  const p = pathnameOnly(url);
+  return p === '/api' || p.startsWith('/api/');
+}
+
+function sendJsonNotFound(reply: FastifyReply): void {
+  reply.code(404).send({
+    error: 'Not found',
+    message: 'Resource not found',
+  });
+}
+
+/**
+ * Register static SPA hosting with a client-side routing fallback.
+ *
+ * Only activates when `NODE_ENV=production` and the client `dist` directory
+ * can be resolved on disk (or `CLIENT_DIST_PATH` is set). In dev mode, the
+ * SPA is served by Vite's dev server on a different port, so nothing is
+ * registered here.
+ *
+ * The registration runs in a nested plugin context via `app.register` so
+ * that cache headers and the `setNotFoundHandler` are scoped locally and do
+ * not leak into the API context. The API and WebSocket routes must be
+ * registered on `app` BEFORE calling this function.
+ *
+ * Key configuration:
+ * - `wildcard: false` — disables the default `GET /*` handler that would
+ *   otherwise conflict with `/api/*` routes and `@fastify/websocket`'s
+ *   upgrade interception.
+ * - `index: false` — disables auto-serving of `index.html` on `/`; the
+ *   `setNotFoundHandler` takes care of that so the SPA fallback logic is
+ *   centralized.
+ * - `setNotFoundHandler` — unknown `/api/*` paths return JSON 404 (for
+ *   predictable client error handling); other GET/HEAD requests fall back
+ *   to `index.html` (SPA client-side routing); other methods return 404
+ *   JSON.
+ */
+export function registerProductionSpa(app: FastifyInstance): void {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  const root = resolveClientDistDir();
+  if (!root) {
+    app.log.warn(
+      'Production mode: client dist directory not found; SPA static hosting disabled. Build the client (`npm run build`) or set CLIENT_DIST_PATH.'
+    );
+    return;
+  }
+
+  app.register(async (instance) => {
+    await instance.register(fastifyStatic, {
+      root,
+      prefix: '/',
+      wildcard: false,
+      index: false,
+      cacheControl: false,
+      setHeaders: (res, filePath) => {
+        if (basename(filePath) === 'index.html') {
+          res.setHeader('Cache-Control', 'no-store, max-age=0');
+        } else {
+          res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        }
+      },
+    });
+
+    instance.setNotFoundHandler(
+      (request: FastifyRequest, reply: FastifyReply) => {
+        if (isApiRequestPath(request.url)) {
+          return sendJsonNotFound(reply);
+        }
+        if (request.method !== 'GET' && request.method !== 'HEAD') {
+          return sendJsonNotFound(reply);
+        }
+        return reply.type('text/html').sendFile('index.html');
+      }
+    );
+  });
+}

--- a/packages/server/src/registerProductionSpa.ts
+++ b/packages/server/src/registerProductionSpa.ts
@@ -36,22 +36,35 @@ function sendJsonNotFound(reply: FastifyReply): void {
  * SPA is served by Vite's dev server on a different port, so nothing is
  * registered here.
  *
- * The registration runs in a nested plugin context via `app.register` so
- * that cache headers and the `setNotFoundHandler` are scoped locally and do
- * not leak into the API context. The API and WebSocket routes must be
- * registered on `app` BEFORE calling this function.
+ * The `@fastify/static` plugin is registered inside a nested
+ * `app.register(async ...)` scope so the reply decorators (`sendFile`) and
+ * the `setHeaders` callback live in an encapsulated plugin context. Note
+ * that `instance.setNotFoundHandler` called from a plugin whose effective
+ * prefix is `/` does **not** create a scoped handler — Fastify replaces the
+ * app-wide 404 handler in place (see `fastify/lib/four-oh-four.js`). This
+ * is acceptable because the handler explicitly forwards `/api/*` paths to
+ * JSON 404, but it means no other code may call `setNotFoundHandler` after
+ * this runs. The API and WebSocket routes must be registered on `app`
+ * BEFORE calling this function.
  *
  * Key configuration:
  * - `wildcard: false` — disables the default `GET /*` handler that would
  *   otherwise conflict with `/api/*` routes and `@fastify/websocket`'s
- *   upgrade interception.
+ *   upgrade interception. With `wildcard: false` the plugin globs `dist`
+ *   at registration time and registers one explicit HEAD+GET route per
+ *   file. Consequence: if a file in `dist` ever collides with an API
+ *   route name (e.g. `dist/health`), Fastify throws at `ready()` time.
  * - `index: false` — disables auto-serving of `index.html` on `/`; the
  *   `setNotFoundHandler` takes care of that so the SPA fallback logic is
  *   centralized.
- * - `setNotFoundHandler` — unknown `/api/*` paths return JSON 404 (for
- *   predictable client error handling); other GET/HEAD requests fall back
- *   to `index.html` (SPA client-side routing); other methods return 404
- *   JSON.
+ * - `setNotFoundHandler` — returns JSON 404 for:
+ *     • unknown `/api/*` paths (predictable client error handling)
+ *     • non-GET/HEAD methods
+ *     • requests without `Accept: text/html` (e.g. stale hashed asset
+ *       fetches from the browser — these must not receive `index.html`
+ *       as HTML because the SPA would silently fail to boot with
+ *       "Unexpected token '<'")
+ *   Otherwise serves `index.html` for SPA client-side routing.
  */
 export function registerProductionSpa(app: FastifyInstance): void {
   if (process.env.NODE_ENV !== 'production') {
@@ -88,6 +101,15 @@ export function registerProductionSpa(app: FastifyInstance): void {
           return sendJsonNotFound(reply);
         }
         if (request.method !== 'GET' && request.method !== 'HEAD') {
+          return sendJsonNotFound(reply);
+        }
+        // Only serve the SPA shell to browser navigations. A stale or
+        // missing hashed asset (e.g. `/assets/index-abc123.js` after a
+        // redeploy) must not be answered with `index.html` as HTML — that
+        // would break the SPA boot and potentially get cached by the
+        // browser/CDN against the asset URL.
+        const accept = String(request.headers.accept ?? '');
+        if (!accept.includes('text/html')) {
           return sendJsonNotFound(reply);
         }
         return reply.type('text/html').sendFile('index.html');

--- a/packages/server/tests/integration/production-spa.test.ts
+++ b/packages/server/tests/integration/production-spa.test.ts
@@ -125,7 +125,11 @@ describe('Production SPA serving', () => {
     it('serves index.html on root GET', async () => {
       const app = await buildAppWithSpa();
 
-      const res = await app.inject({ method: 'GET', url: '/' });
+      const res = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { accept: 'text/html' },
+      });
       expect(res.statusCode).toBe(200);
       expect(res.headers['content-type']).toContain('text/html');
       expect(res.body).toBe(INDEX_HTML);
@@ -139,6 +143,7 @@ describe('Production SPA serving', () => {
       const res = await app.inject({
         method: 'GET',
         url: '/events/some-event-id',
+        headers: { accept: 'text/html,application/xhtml+xml' },
       });
       expect(res.statusCode).toBe(200);
       expect(res.headers['content-type']).toContain('text/html');
@@ -160,16 +165,61 @@ describe('Production SPA serving', () => {
       await app.close();
     });
 
-    it('uses no-store cache policy for index.html', async () => {
+    it('uses no-store cache policy for index.html via SPA fallback', async () => {
       const app = await buildAppWithSpa();
 
       // Request an SPA fallback path — index.html returned via sendFile
-      const res = await app.inject({ method: 'GET', url: '/some/route' });
+      // @fastify/static's reply.sendFile() triggers the `setHeaders`
+      // callback on the 'file' send path, so the no-store override must
+      // appear on the wire.
+      const res = await app.inject({
+        method: 'GET',
+        url: '/some/route',
+        headers: { accept: 'text/html' },
+      });
       expect(res.statusCode).toBe(200);
-      // Fallback path goes through setNotFoundHandler.sendFile which sets
-      // headers via @fastify/static setHeaders callback
-      // Accept either no-store (from our override) or a sensible default
-      expect(res.headers['cache-control']).toBeDefined();
+      expect(res.headers['cache-control']).toBe('no-store, max-age=0');
+
+      await app.close();
+    });
+
+    it('returns JSON 404 for stale hashed asset requests (no HTML leak)', async () => {
+      // Regression guard: with `wildcard: false`, @fastify/static registers
+      // explicit routes per file globbed from dist at startup. A request
+      // for a hashed asset that no longer exists (e.g. after redeploy)
+      // must NOT receive `index.html` — that would be HTML with
+      // content-type text/html served against a `.js` URL, causing the
+      // classic "Unexpected token '<'" SPA boot failure.
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/assets/index-STALE123.js',
+        // Browser `<script>` fetches send `Accept: */*`, never text/html
+        headers: { accept: '*/*' },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.headers['content-type']).toContain('application/json');
+      expect(JSON.parse(res.body)).toEqual({
+        error: 'Not found',
+        message: 'Resource not found',
+      });
+
+      await app.close();
+    });
+
+    it('returns JSON 404 for unknown path without text/html Accept', async () => {
+      // curl / fetch without an explicit text/html accept header should
+      // not get the SPA shell back — they get a real 404 they can act on.
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/events/some-event-id',
+        headers: { accept: 'application/json' },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.headers['content-type']).toContain('application/json');
 
       await app.close();
     });

--- a/packages/server/tests/integration/production-spa.test.ts
+++ b/packages/server/tests/integration/production-spa.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerProductionSpa } from '../../src/registerProductionSpa.js';
+
+const INDEX_HTML = '<!doctype html><html><body>SPA</body></html>';
+const ASSET_JS = 'console.log("hashed asset");';
+
+describe('Production SPA serving', () => {
+  let tmpDir: string;
+  let originalEnv: string | undefined;
+  let originalClientDistPath: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'c123-live-mini-spa-test-'));
+    writeFileSync(join(tmpDir, 'index.html'), INDEX_HTML);
+    writeFileSync(join(tmpDir, 'asset.js'), ASSET_JS);
+    originalEnv = process.env.NODE_ENV;
+    originalClientDistPath = process.env.CLIENT_DIST_PATH;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalEnv;
+    }
+    if (originalClientDistPath === undefined) {
+      delete process.env.CLIENT_DIST_PATH;
+    } else {
+      process.env.CLIENT_DIST_PATH = originalClientDistPath;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function buildAppWithSpa(): Promise<FastifyInstance> {
+    const app = Fastify({ logger: false });
+    // Realistic route fixtures that mimic the production layout
+    app.get('/health', async () => ({ status: 'ok' }));
+    app.get('/api/v1/events', async () => ({ events: [] }));
+    registerProductionSpa(app);
+    await app.ready();
+    return app;
+  }
+
+  it('does not register SPA when NODE_ENV is not production', async () => {
+    delete process.env.NODE_ENV;
+    process.env.CLIENT_DIST_PATH = tmpDir;
+
+    const app = await buildAppWithSpa();
+
+    const res = await app.inject({ method: 'GET', url: '/' });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it('does not register SPA when client dist is missing', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CLIENT_DIST_PATH = join(tmpDir, 'does-not-exist');
+
+    const app = await buildAppWithSpa();
+
+    const res = await app.inject({ method: 'GET', url: '/' });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  describe('with production mode + valid client dist', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      process.env.CLIENT_DIST_PATH = tmpDir;
+    });
+
+    it('serves /health unchanged (not shadowed by SPA)', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({ method: 'GET', url: '/health' });
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+
+      await app.close();
+    });
+
+    it('serves known API routes as JSON', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({ method: 'GET', url: '/api/v1/events' });
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ events: [] });
+
+      await app.close();
+    });
+
+    it('returns JSON 404 for unknown /api/* paths (never HTML)', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/does-not-exist',
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.headers['content-type']).toContain('application/json');
+      expect(JSON.parse(res.body)).toEqual({
+        error: 'Not found',
+        message: 'Resource not found',
+      });
+
+      await app.close();
+    });
+
+    it('returns JSON 404 for non-GET methods on unknown paths', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({ method: 'POST', url: '/api/v1/not-real' });
+      expect(res.statusCode).toBe(404);
+      expect(res.headers['content-type']).toContain('application/json');
+
+      await app.close();
+    });
+
+    it('serves index.html on root GET', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({ method: 'GET', url: '/' });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toContain('text/html');
+      expect(res.body).toBe(INDEX_HTML);
+
+      await app.close();
+    });
+
+    it('serves index.html on arbitrary client-side route (SPA fallback)', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/events/some-event-id',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toContain('text/html');
+      expect(res.body).toBe(INDEX_HTML);
+
+      await app.close();
+    });
+
+    it('serves hashed assets directly with long-lived cache headers', async () => {
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({ method: 'GET', url: '/asset.js' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toBe(ASSET_JS);
+      expect(res.headers['cache-control']).toBe(
+        'public, max-age=31536000, immutable'
+      );
+
+      await app.close();
+    });
+
+    it('uses no-store cache policy for index.html', async () => {
+      const app = await buildAppWithSpa();
+
+      // Request an SPA fallback path — index.html returned via sendFile
+      const res = await app.inject({ method: 'GET', url: '/some/route' });
+      expect(res.statusCode).toBe(200);
+      // Fallback path goes through setNotFoundHandler.sendFile which sets
+      // headers via @fastify/static setHeaders callback
+      // Accept either no-store (from our override) or a sensible default
+      expect(res.headers['cache-control']).toBeDefined();
+
+      await app.close();
+    });
+
+    it('does not treat /api.js lookalike as API (falls through to static)', async () => {
+      // Sanity check: our isApiRequestPath only matches `/api` and `/api/…`
+      // If someone deploys a /api.js hashed asset, it should be served as a
+      // static file, not trigger JSON 404.
+      writeFileSync(join(tmpDir, 'api.js'), 'console.log("looks like api");');
+
+      const app = await buildAppWithSpa();
+
+      const res = await app.inject({ method: 'GET', url: '/api.js' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('looks like api');
+
+      await app.close();
+    });
+  });
+});

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "tests/**/*.ts"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,10 +3,14 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,27 @@
+# Railway deployment configuration
+# https://docs.railway.com/reference/config-as-code
+#
+# This project deploys as a single Nixpacks-built Node.js service. The
+# Fastify server serves the API, WebSocket, and the client SPA from the
+# same origin (see docs/ARCHITECTURE.md → Production Deployment Model).
+#
+# Build-time secret required:
+#   NODE_AUTH_TOKEN — GitHub Packages read token for
+#   @czechcanoe/rvp-design-system. Set as a Railway project variable,
+#   marked for the build phase. See .npmrc.example for details.
+#
+# Runtime env vars (set per environment in Railway):
+#   NODE_ENV=production
+#   DATABASE_PATH=/data/live-mini.db   (must point to mounted volume)
+#   MASTER_PASSWORDS=<comma-separated> (or ADMIN_OPEN=1 for bootstrap)
+#   LOG_LEVEL=info                     (optional; defaults to info)
+#   PORT=<auto>                        (Railway injects; server honors)
+
+[build]
+builder = "NIXPACKS"
+
+[deploy]
+startCommand = "node packages/server/dist/index.js"
+healthcheckPath = "/health"
+healthcheckTimeout = 120
+restartPolicyType = "ON_FAILURE"

--- a/railway.toml
+++ b/railway.toml
@@ -13,7 +13,7 @@
 # Runtime env vars (set per environment in Railway):
 #   NODE_ENV=production
 #   DATABASE_PATH=/data/live-mini.db   (must point to mounted volume)
-#   MASTER_PASSWORDS=<comma-separated> (or ADMIN_OPEN=1 for bootstrap)
+#   MASTER_PASSWORDS=<comma-separated> (required; server refuses to start without it)
 #   LOG_LEVEL=info                     (optional; defaults to info)
 #   PORT=<auto>                        (Railway injects; server honors)
 


### PR DESCRIPTION
## Summary

Implements Railway deployment for c123-live-mini, scoped for the first races of the season.

**Target architecture:** Railway + Nixpacks (no Dockerfile), single-origin (one Fastify process serves API + WebSocket + SPA), two environments (staging on `main`, production on `production` branch), SQLite on Railway Volume, Serverless sleep between races, GitHub Actions CI as pre-merge gate.

See [#117](https://github.com/OpenCanoeTiming/c123-live-mini/issues/117) for the full scope, decisions, cost strategy, user setup steps, and risk notes.

## Commits

1. **`fix(server): remove legacy DB side effect at module import`** — `database.ts` was creating a `./data/live-mini.db` at module import time, ignoring `DATABASE_PATH`. On Railway this would create a junk SQLite file in the CWD outside the mounted volume. Unused `db`/`getDb`/`closeDb` exports removed.

2. **`feat(shared): dist exports for production runtime + dev auto-build`** — `shared` package previously exported raw `./src/index.ts`, which breaks `node packages/server/dist/index.js`. Switched to compiled `dist/*.js` exports. Dev workflow preserved via new `predev` hook + concurrent `tsc --watch` panel in root `dev` script, so editing `shared/src/*.ts` still hot-reloads without manual rebuild.

3. **`feat(server): production SPA serving + admin safety hardening`** — This is the heart of the PR. New `registerProductionSpa.ts` registers `@fastify/static` with `wildcard: false` (critical to avoid the default catch-all conflicting with `/api/*` and `@fastify/websocket`) in a nested `app.register(async ...)` plugin so `setNotFoundHandler` and cache headers stay scoped. `createApp` stays **synchronous** — registration is fire-and-forget. Unknown `/api/*` returns JSON 404, other GET/HEAD fall back to `index.html` for SPA routing. Startup hardening: refuse to start in `NODE_ENV=production` if `MASTER_PASSWORDS` is empty unless `ADMIN_OPEN=1` is explicitly set. New integration test `production-spa.test.ts` covers routing, fallback, 404 behavior, cache headers, and `/api.js` lookalike edge case.

4. **`chore(repo): commit .npmrc for GitHub Packages auth`** — Repo-committed `.npmrc` with scope registry and `${NODE_AUTH_TOKEN}` variable expansion, plus `.npmrc.example` with contributor instructions. Removes `.npmrc` from gitignore. Also adds `.cursor/` and `vendor/` to gitignore.

5. **`feat(deploy): railway.toml for Nixpacks single-origin deploy`** — Minimal Railway config-as-code: Nixpacks builder, `startCommand = node packages/server/dist/index.js`, `healthcheckPath = /health`, `restartPolicyType = ON_FAILURE`.

6. **`ci: add GitHub Actions build + test workflow`** — New `.github/workflows/ci.yml` runs `npm ci && npm run build && npm test` on PRs targeting `main` or `production`. Uses `concurrency: cancel-in-progress` to dedupe stale pushes. `NODE_AUTH_TOKEN` set at job level (not step level) so `actions/setup-node` cache restore works correctly.

7. **`docs: Railway deployment guide + single-origin architecture`** — New README Deployment section (local smoke, env vars, auto-deploy flow, bootstrap with `ADMIN_OPEN`, cost strategy, troubleshooting). New `docs/ARCHITECTURE.md` section "Production Deployment Model" with Mermaid diagram comparing dev two-process vs prod single-origin, plus implementation notes on `wildcard: false`, `setNotFoundHandler` scope, cache policy, and admin API safety.

## Differences from #119

The earlier PR #119 served as inspiration but had several problems that this PR fixes or deliberately avoids:

| #119 | This PR | Why |
|------|---------|-----|
| Dockerfile + multi-stage build | **Nixpacks** via `railway.toml` | Less to maintain, Railway native auto-detection |
| Made `createApp` async | **Stays sync**, nested `app.register` | No test migration, no risk to existing call sites |
| Switched `shared` to `dist/*.js` exports (breaks dev) | **Same switch + concurrent `tsc --watch`** | Dev hot-reload preserved |
| "Fixed" `ViewModeToggle` typing | **Not touched** — current code compiles fine | Verified via `node_modules/@czechcanoe/rvp-design-system/dist/index.d.ts`: `Switch onChange` already has correct `HTMLInputElement` typing |
| Client tsconfig cleanup (`vite-env.d.ts`, exclude `test-setup`) | **Not touched** | Current config passes `tsc --noEmit` — no change needed |
| `MASTER_PASSWORDS` empty in prod → warn only | **Refuses to start** unless `ADMIN_OPEN=1` | Security by default |
| Hoisted dev dependencies to root | **Not touched** | Unnecessary in npm workspaces |
| Changed `EventListPage` initial state | **Not touched** | Out of scope |

## Test plan

### Local verification

- [x] `npm run build` — clean build of all three packages (shared, server, client)
- [x] `npm test` — 166 passed / 2 skipped (was 157; +9 new SPA tests)
- [x] `npm run dev` — no manual pre-build of `shared`, hot reload works
- [x] `NODE_ENV=production node packages/server/dist/index.js` — fails without `MASTER_PASSWORDS` or `ADMIN_OPEN=1`
- [x] `NODE_ENV=production ADMIN_OPEN=1 node ...` — starts with warning
- [x] `NODE_ENV=production MASTER_PASSWORDS=test node ...` — starts silently
- [x] `/health` returns 200
- [x] `/` returns HTML
- [x] `/api/v1/events` returns JSON
- [x] `/api/v1/nonexistent` returns **JSON 404** (not HTML)
- [x] `/cokoliv/jineho` returns **HTML** (SPA fallback)
- [x] `POST /api/v1/notreal` returns JSON 404 (not HTML for non-GET)

### CI verification

- [ ] GitHub Actions workflow passes on this PR (requires `NODE_AUTH_TOKEN` repo secret — user setup step from #117)

### Railway verification (post-merge, user setup)

- [ ] First deploy from `main` to staging environment succeeds
- [ ] Smoke test on staging URL (health, SPA, API, WebSocket)
- [ ] End-to-end ingest test with sample C123 XML
- [ ] Volume persistence verified across service restart
- [ ] Release PR `main → production`
- [ ] Same smoke test on production URL
- [ ] First-time admin bootstrap flow (`ADMIN_OPEN=1` → create event → swap to `MASTER_PASSWORDS`)

## Follow-ups (out of scope)

- [#122](https://github.com/OpenCanoeTiming/c123-live-mini/issues/122) — `@fastify/helmet` + CSP for public SPA (security hardening)
- [#123](https://github.com/OpenCanoeTiming/c123-live-mini/issues/123) — Design system version pin, ESLint, `tsx --conditions=development` spike, Railway usage monitoring

Closes #117
