### PR TITLE
fix(deploy): pin engines.node to ^20.19.0 for Nixpacks + Vite 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vitest": "^4.1.2"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "^20.19.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

First Railway deploy (#121 / #117 follow-up) failed at the client build step:

\`\`\`
You are using Node.js 22.11.0. Vite requires Node.js version 20.19+ or 22.12+.
\`\`\`

Followed by a secondary rolldown native-binding error (npm#4828) — both symptoms of Nixpacks picking up Node 22.11 from our too-permissive \`engines.node: '>=20.0.0'\`.

## Fix

Narrow \`engines.node\` to \`^20.19.0\`. This:
- Forces Nixpacks (and any other toolchain reading \`engines\`) to pick the Node 20 LTS line
- Matches the version local dev + GitHub Actions CI run on
- Matches the lockfile that already contains the correct \`@rolldown/binding-linux-x64-gnu\` optional dep

## Test plan

- [x] \`npm run build\` — clean (shared → server → client)
- [x] \`npm test\` — 168 passed / 2 skipped (unchanged)
- [ ] CI green on this PR
- [ ] Railway redeploys from main, client build succeeds past the \`vite build\` step

## Context

Discovered during the first Railway staging deploy under #117. Unblocks the rollout.