### PR TITLE
fix(deploy): split vite.config.ts from vitest (Railway unblocker)

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -13,11 +12,5 @@ export default defineConfig({
         ws: true,
       },
     },
-  },
-  test: {
-    name: 'client',
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,21 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// Separate vitest config so that `vite build` (production) does not
+// transitively load the vitest package and its Vite 8 / Rolldown chain.
+// Vitest 4 depends on Vite 8, which pulls in `@rolldown/binding-linux-*`
+// native addons. On some CI and cloud build environments npm skips those
+// optional platform bindings (npm#4828) and the config load explodes.
+// By keeping vite.config.ts completely vitest-free, production `vite build`
+// resolves only to `packages/client/node_modules/vite` (v7.1.x) and never
+// touches Rolldown.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    name: 'client',
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -3,5 +3,5 @@ import { defineWorkspace } from 'vitest/config'
 export default defineWorkspace([
   './packages/shared/vitest.config.ts',
   './packages/server/vitest.config.ts',
-  './packages/client/vite.config.ts',
+  './packages/client/vitest.config.ts',
 ])


### PR DESCRIPTION
Split client `vite.config.ts` into pure vite config + new `vitest.config.ts`. The old unified config pulled vitest's transitive vite@8 → rolldown chain into the config-bundle step on Railway's linux-x64 runner, where npm#4828 drops the rolldown native binding. Production `vite build` now touches no rolldown code. `vitest.workspace.ts` rewired.

Local: 168 tests green, vite v7.1.12 builds clean.

Third follow-up fix for #117 (after #121 → #124 → #125).