### PR TITLE
docs: add ops runbook + tighten gitignore for token files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ packages/*/package-lock.json
 .env.local
 .env.*.local
 
+# Secrets — never commit tokens, keys, credentials
+*.token
+.secrets/
+secrets/
+.railway-token
+.railway.env
+
 # Cursor — local AI rules, not part of the product
 .cursor/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ C123 Live Mini - minimalistic live results for canoe slalom races timed with Can
 | Database | SQLite file-based (`packages/server/data/live-mini.db`), Repository Pattern |
 | Frontend | React 18, Vite, wouter |
 | Design System | @czechcanoe/rvp-design-system (public-facing) |
-| Deployment | Railway (planned) |
+| Deployment | Railway (staging live, production deferred) — see `docs/RUNBOOK.md` |
 
 ---
 
@@ -37,6 +37,8 @@ C123 Live Mini - minimalistic live results for canoe slalom races timed with Can
 | Purpose | Path |
 |---------|------|
 | **Architecture & data flows** | `docs/ARCHITECTURE.md` |
+| **Deployment runbook** (staging URL, Railway access, smoke tests, troubleshooting) | `docs/RUNBOOK.md` |
+| **Post-mortems / lessons** | `DEVLOG.md` |
 | **C123 protocol (XML, TCP)** | `../c123-protocol-docs/` |
 | **c123-server (data source)** | `../c123-server/` |
 | **Design system** | [rvp-design-system](https://github.com/CzechCanoe/rvp-design-system/) |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,309 @@
+# Operations Runbook
+
+Quick-reference operations guide for running c123-live-mini on Railway. Read this first when you come back to the project after a break, or when something is broken in production.
+
+For deep architecture see [ARCHITECTURE.md](ARCHITECTURE.md). For historical debugging stories see [../DEVLOG.md](../DEVLOG.md).
+
+---
+
+## Environments
+
+| Environment | Branch watched | URL | Railway env name | Status |
+|---|---|---|---|---|
+| **staging** | `main` | https://c123-live-mini-staging.up.railway.app | `staging` | ✅ live |
+| **production** | `production` | *(not yet created)* | `production` | ⏸ deferred, see issue [#117](https://github.com/OpenCanoeTiming/c123-live-mini/issues/117) |
+
+**Auto-deploy flow:** push to `main` → GitHub Actions CI runs `npm ci && npm run build && npm test` → on green, Railway auto-deploys staging. Railway has **Wait for CI = ON**, so a failed CI check blocks the deploy.
+
+**Serverless sleep:** enabled. After ~10 min of no traffic, the container sleeps. First request after sleep has cold-start latency ~5–10 s (Nixpacks wake + Node boot + SQLite open). During a live race this is a non-issue because traffic is continuous.
+
+---
+
+## Smoke test checklist
+
+Copy-paste to verify staging after any deploy:
+
+```bash
+URL="https://c123-live-mini-staging.up.railway.app"
+
+# 1. Health
+curl -sS -w "\nHTTP %{http_code}\n" "$URL/health"
+# expect: {"status":"ok"} + HTTP 200
+
+# 2. SPA shell (browser-like)
+curl -sS -H 'Accept: text/html' -I "$URL/" | grep -iE "HTTP|cache-control|content-type"
+# expect: HTTP 200, content-type text/html, cache-control: no-store, max-age=0
+
+# 3. SPA client-side route fallback
+curl -sS -H 'Accept: text/html' -I "$URL/events/live-mini" | grep -i "HTTP"
+# expect: HTTP 200
+
+# 4. API list
+curl -sS -w "\nHTTP %{http_code}\n" "$URL/api/v1/events"
+# expect: JSON events array + HTTP 200
+
+# 5. Unknown API route → JSON 404
+curl -sS -w "\nHTTP %{http_code}\n" "$URL/api/v1/nonexistent"
+# expect: {"error":"Not found",...} + HTTP 404
+
+# 6. Stale asset fallback guard (regression test for #121 review)
+curl -sS -H 'Accept: */*' -w "\nHTTP %{http_code}\n" "$URL/assets/index-STALE123.js"
+# expect: JSON 404, NOT HTML
+
+# 7. Admin auth enforcement
+curl -sS -X POST -H "Content-Type: application/json" \
+  -d '{"eventId":"test","mainTitle":"Test"}' \
+  -w "\nHTTP %{http_code}\n" "$URL/api/v1/admin/events"
+# expect: 401 Unauthorized (no X-Master-Key header)
+```
+
+---
+
+## Railway access & secrets
+
+### Where the Railway project token lives
+
+The Railway project token is **scoped per-project** (staging only) with full read/write access. Treat it like a password — do **not** commit it.
+
+Persistence on your dev machine (RPi5):
+
+| Location | What for | Managed by |
+|---|---|---|
+| `~/.bashrc` — `export RAILWAY_TOKEN=...` | Auto-exported in every interactive shell, so `railway` CLI and any ad-hoc `curl` to Railway GraphQL API just work. | Manually edited (see below) |
+| `~/.config/c123-live-mini/railway.env` | Standalone backup file with metadata — project ID, service ID, environment IDs — in one place. Can be sourced with `source ~/.config/c123-live-mini/railway.env`. | Manually maintained |
+| A password manager entry (recommended) | Long-term recovery source of truth. | You, manually |
+
+### Regenerating the token (if lost or compromised)
+
+1. https://railway.app/ → project `skvs-live-mini` → **Project Settings** (gear icon)
+2. **Tokens** tab → **Create Token** → scope: **Project**, environment: **staging** (or Shared) → copy
+3. Revoke any old token from the same page
+4. Update `~/.bashrc` and `~/.config/c123-live-mini/railway.env` with the new value
+5. Open a new shell (or `source ~/.bashrc`)
+
+### Where the GitHub Packages token lives
+
+Separate token, used at build time to pull `@czechcanoe/rvp-design-system`. Scope: `read:packages`. Stored in:
+
+- `~/.bashrc` → `export NODE_AUTH_TOKEN=...` (for local `npm install`)
+- **GitHub Actions repo secret** `NODE_AUTH_TOKEN` (for CI)
+- **Railway project variable** `NODE_AUTH_TOKEN` (for Nixpacks build phase)
+
+Project-committed `.npmrc` uses `${NODE_AUTH_TOKEN}` variable expansion, so the token must be in the environment when `npm install` / `npm ci` runs.
+
+---
+
+## Runtime operations
+
+All three paths below work from this box (token already exported in `~/.bashrc`):
+
+### Fetching runtime logs
+
+**Via Railway Dashboard** — Project → service `c123-live-mini` → Deployments → click active deployment → View Logs panel. Real-time streaming, filter by severity, timestamp scroll.
+
+**Via Railway CLI (`railway ssh`)** — interactive:
+```bash
+railway ssh --service c123-live-mini --environment staging
+# you're now inside the container
+```
+
+**Via GraphQL API (for scripting / ad-hoc queries)** — wrapper one-liner with the env IDs:
+```bash
+DEP_ID=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d '{"query":"query { deployments(first: 10, input: { projectId: \"97408870-7b9e-4aa5-b3b1-5b546e4d1f34\", environmentId: \"b1c8ea80-c260-4819-bc9e-54de1a27fd62\", serviceId: \"aadf519a-48b5-4da9-9259-21b9178a2619\" }) { edges { node { id status } } } }"}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); [print(e['node']['id']) or exit() for e in d['data']['deployments']['edges'] if e['node']['status']=='SUCCESS']")
+
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"query\":\"query { deploymentLogs(deploymentId: \\\"$DEP_ID\\\", limit: 50) { message severity timestamp } }\"}" \
+  | python3 -c "import json,sys,d=json.load(sys.stdin); [print(l['timestamp'][:19], l.get('severity','info')[:4], l['message'].rstrip()) for l in d['data']['deploymentLogs']]"
+```
+
+For build-time logs (Nixpacks build output), use `buildLogs(deploymentId:...)` instead of `deploymentLogs`.
+
+### Inspecting the `/data` volume (SQLite DB)
+
+Volume is mounted at `/data`. Single file `live-mini.db`.
+
+**Size and file listing:**
+```bash
+railway ssh --service c123-live-mini --environment staging -- 'du -sh /data && ls -lah /data/'
+```
+
+**SQLite schema / row counts / per-table disk usage** via better-sqlite3 in the container (sqlite3 CLI is not installed in the Nixpacks image):
+```bash
+SCRIPT=$(cat <<'EOF'
+const db = require('better-sqlite3')('/data/live-mini.db', { readonly: true });
+const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name").all();
+console.log('=== Tables ===');
+let total = 0;
+for (const t of tables) {
+  const c = db.prepare(`SELECT COUNT(*) AS c FROM "${t.name}"`).get().c;
+  total += c;
+  console.log(t.name.padEnd(30), String(c).padStart(8), 'rows');
+}
+console.log('Total rows:', total);
+// Per-table disk usage via dbstat vtab
+const rows = db.prepare("SELECT name, SUM(payload) AS b FROM dbstat WHERE name IN (SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%') GROUP BY name ORDER BY b DESC").all();
+console.log('=== Per-table disk bytes ===');
+for (const r of rows) console.log(r.name.padEnd(30), String(Math.round(r.b/1024)).padStart(6), 'KB');
+db.close();
+EOF
+)
+B64=$(echo "$SCRIPT" | base64 -w0)
+railway ssh --service c123-live-mini --environment staging -- "cd /app && echo $B64 | base64 -d | node"
+```
+
+Why base64: it avoids quote-escaping hell when passing a multiline JS snippet through two shell layers (local shell → Railway SSH → container shell).
+
+### Forcing a redeploy
+
+From CLI:
+```bash
+railway redeploy --service c123-live-mini --environment staging --yes
+```
+
+Or via GraphQL mutation (bypasses CLI quirks with project-token service resolution):
+```bash
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d '{"query":"mutation { serviceInstanceDeployV2(serviceId: \"aadf519a-48b5-4da9-9259-21b9178a2619\", environmentId: \"b1c8ea80-c260-4819-bc9e-54de1a27fd62\") }"}'
+```
+
+Or the lazy way: push an empty commit to `main` (`git commit --allow-empty -m "chore: trigger redeploy" && git push`) — Railway picks it up automatically.
+
+### Inspecting / updating env vars
+
+List (values of tokens/passwords are real but not redacted by the API — review output carefully before pasting anywhere):
+```bash
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d '{"query":"query { variables(projectId: \"97408870-7b9e-4aa5-b3b1-5b546e4d1f34\", environmentId: \"b1c8ea80-c260-4819-bc9e-54de1a27fd62\", serviceId: \"aadf519a-48b5-4da9-9259-21b9178a2619\") }"}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin)['data']['variables']; [print(k,'=', ('<REDACTED>' if any(s in k.upper() for s in ['TOKEN','PASSWORD','KEY','SECRET','AUTH']) else v)) for k,v in sorted(d.items())]"
+```
+
+Set / update a variable:
+```bash
+NAME=MY_VAR VALUE=hello
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"query\":\"mutation { variableUpsert(input: { projectId: \\\"97408870-7b9e-4aa5-b3b1-5b546e4d1f34\\\", environmentId: \\\"b1c8ea80-c260-4819-bc9e-54de1a27fd62\\\", serviceId: \\\"aadf519a-48b5-4da9-9259-21b9178a2619\\\", name: \\\"$NAME\\\", value: \\\"$VALUE\\\" }) }\"}"
+```
+
+Delete:
+```bash
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d '{"query":"mutation { variableDelete(input: { projectId: \"97408870-7b9e-4aa5-b3b1-5b546e4d1f34\", environmentId: \"b1c8ea80-c260-4819-bc9e-54de1a27fd62\", serviceId: \"aadf519a-48b5-4da9-9259-21b9178a2619\", name: \"MY_VAR\" }) }"}'
+```
+
+---
+
+## Railway IDs (staging)
+
+Useful for scripting — these are not secret:
+
+| What | Value |
+|---|---|
+| Project | `skvs-live-mini` |
+| Project ID | `97408870-7b9e-4aa5-b3b1-5b546e4d1f34` |
+| Environment name | `staging` |
+| Environment ID | `b1c8ea80-c260-4819-bc9e-54de1a27fd62` |
+| Service name | `c123-live-mini` |
+| Service ID | `aadf519a-48b5-4da9-9259-21b9178a2619` |
+| Volume mount | `/data` |
+| Public domain | `c123-live-mini-staging.up.railway.app` |
+
+---
+
+## Environment variables currently set on Railway staging
+
+| Variable | Purpose | Source |
+|---|---|---|
+| `NODE_ENV=production` | Activates SPA serving + admin safety check | Manual |
+| `DATABASE_PATH=/data/live-mini.db` | SQLite on mounted volume | Manual |
+| `MASTER_PASSWORDS=<strong-password>` | Admin API auth, required in prod | Manual (generated with `openssl rand -base64 24`) |
+| `NODE_AUTH_TOKEN=<GH PAT>` | Build-phase GitHub Packages auth for `@czechcanoe/rvp-design-system` | Manual |
+| `LOG_LEVEL=info` | Fastify logger level | Manual |
+| `RAILWAY_*` | Service metadata (private domain, volume mount, etc.) | Railway-injected, read-only |
+
+Note: `NIXPACKS_NODE_VERSION` and `NPM_CONFIG_INCLUDE` were tried during the Railway debugging session and **removed** in the final working state — the vite override fix made them unnecessary. See DEVLOG 2026-04-10.
+
+---
+
+## First-time bootstrap (after a fresh Railway deploy or DB reset)
+
+The server refuses to start without `MASTER_PASSWORDS` in `NODE_ENV=production`, so the password must be set **before** first deploy. To create the first event once the service is live:
+
+```bash
+URL="https://c123-live-mini-staging.up.railway.app"
+MK="<your master password>"
+
+curl -X POST "$URL/api/v1/admin/events" \
+  -H 'Content-Type: application/json' \
+  -H "X-Master-Key: $MK" \
+  -d '{"eventId":"bootstrap","mainTitle":"Bootstrap event"}'
+# response contains the `apiKey` used by c123-server to POST ingest data
+```
+
+Save the returned `apiKey` — it's how c123-server authenticates its data pushes.
+
+---
+
+## Troubleshooting
+
+### Deploy failing in CI / Railway build with rolldown / native binding error
+
+Check `node_modules/rolldown/` was not re-introduced. The CI regression guard in `.github/workflows/ci.yml` should catch this automatically, but if you hit it locally:
+- Look at `package.json` root `overrides.vite` — it should still pin `~7.1.9`
+- `npm ls vite` should report exactly one resolved version
+
+Full story: [DEVLOG 2026-04-10](../DEVLOG.md).
+
+### Deploy showing as FAILED in Railway but no obvious error in the log
+
+Pull the full build log via GraphQL (the Dashboard sometimes truncates):
+```bash
+railway logs --deployment <id>
+# or via GraphQL buildLogs query (see "Fetching runtime logs" above)
+```
+
+If the build phase is clean and healthcheck times out, the server is probably crashing at start. Check runtime logs:
+```bash
+# Latest failed deployment ID from GraphQL
+curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" -H "Content-Type: application/json" \
+  -d '{"query":"query { deployments(first: 3, input: { projectId: \"97408870-7b9e-4aa5-b3b1-5b546e4d1f34\", environmentId: \"b1c8ea80-c260-4819-bc9e-54de1a27fd62\", serviceId: \"aadf519a-48b5-4da9-9259-21b9178a2619\" }) { edges { node { id status createdAt } } } }"}' \
+  | python3 -m json.tool
+```
+
+Most common crashes:
+- `[FATAL] NODE_ENV=production requires MASTER_PASSWORDS` → env var missing / misspelled
+- `EACCES /data/...` → volume not mounted or misconfigured
+- `ENOENT packages/client/dist/...` → build didn't produce SPA assets (typically a vite error upstream in the same deploy)
+
+### Service not waking up after Serverless sleep
+
+The first request after sleep takes 5–10 s. If you need to force a wake (e.g. before a race), just hit `/health` once and ignore the result.
+
+### Volume near the Free plan limit (500 MB)
+
+Unlikely for the foreseeable future — see DEVLOG 2026-04-10 estimates (~60 days of continuous racing to fill it). But if it happens:
+- The `results` table dominates (~95 %) — archiving old events (move `results`/`races` rows out) would reclaim most of it
+- `ingest_records` is small (metadata only, no payloads) — no meaningful savings there
+- A SQL `VACUUM` on the live DB will compact freelist pages, but note it locks the DB briefly
+
+### GitHub Actions CI failing with 401 on `npm ci`
+
+`NODE_AUTH_TOKEN` repo secret is missing, expired, or not SSO-authorized for the `CzechCanoe` organization. See [.npmrc.example](../.npmrc.example) for setup.
+
+---
+
+## Links
+
+- Issue: [#117 Deployment configuration](https://github.com/OpenCanoeTiming/c123-live-mini/issues/117)
+- Architecture: [ARCHITECTURE.md § Production Deployment Model](ARCHITECTURE.md#production-deployment-model)
+- Post-mortem: [DEVLOG 2026-04-10](../DEVLOG.md)
+- Railway docs: https://docs.railway.com/
+- Railway status: https://status.railway.com/


### PR DESCRIPTION
Ops quick-reference for coming back to the project after a break.

## What's in `docs/RUNBOOK.md`

- Environments table (staging live, production deferred)
- Smoke-test checklist (copy-paste curl commands)
- Railway token location + regeneration flow
- How to fetch runtime logs (Dashboard / \`railway ssh\` / GraphQL API)
- How to SSH into the container and inspect the \`/data\` SQLite volume (including a ready-made Node+dbstat snippet for per-table disk usage)
- How to force a redeploy
- How to list/upsert/delete Railway env vars via GraphQL
- Full Railway IDs table (project / env / service UUIDs) for scripting
- Current staging env var inventory
- First-time admin bootstrap flow
- Troubleshooting crumbs for the issues we hit today (rolldown regression, crashed deploys, cold start, volume limit, 401 on \`npm ci\`)

Cross-links to \`ARCHITECTURE.md\` (deep architecture), \`DEVLOG.md\` (post-mortem), and issue #117 (open production work).

## Other changes

- \`CLAUDE.md\` — Key References table now points at RUNBOOK.md and DEVLOG.md; Deployment row updated to reflect actual staging-live / production-deferred state.
- \`.gitignore\` — added \`*.token\`, \`.secrets/\`, \`secrets/\`, \`.railway-token\`, \`.railway.env\` to the Secrets section as belt-and-braces protection. Verified with a sandbox test — all patterns are caught.

## What is NOT committed (intentionally)

The Railway project token itself is never in the repo. It lives in:
- \`~/.bashrc\` on the dev box (auto-exported in every interactive shell)
- \`~/.config/c123-live-mini/railway.env\` (chmod 600) — a user-config file with the token and the non-secret convenience IDs (project/env/service UUIDs). Can be \`source\`-d as a one-shot environment setup.
- Railway Dashboard (regenerable there, source of truth)

If the token leaks or is lost, regenerate from Railway Dashboard → Project Settings → Tokens.

No runtime changes.