### PR TITLE
feat(client): configurable branding + homepage hero (#120)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -239,6 +239,25 @@ Both staging and production share the same set; values differ only for `MASTER_P
 
 Note: `NIXPACKS_NODE_VERSION` and `NPM_CONFIG_INCLUDE` were tried during the Railway debugging session and **removed** in the final working state — the vite override fix made them unnecessary. See DEVLOG 2026-04-10.
 
+### Build-time client branding (`VITE_*`)
+
+These variables are read by Vite **during the Nixpacks build phase** (`vite build` step) and baked into the JS bundle. Changing a value requires a **redeploy** for the SPA to pick it up — they are NOT runtime config. All have safe defaults baked into the source so unsetting them reproduces the original ČSK Live deployment exactly.
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `VITE_APP_NAME` | `ČSK Live` | Header title (satellite breadcrumb) **and** homepage hero title |
+| `VITE_APP_SUBTITLE` | `Živé výsledky kanoistického slalomu` | Homepage hero subtitle |
+| `VITE_HOME_LINK` | `https://kanoe.cz` | Satellite header back-link URL |
+| `VITE_HOME_LINK_LABEL` | `Zpět na kanoe.cz` | Satellite header back-link text |
+
+To change branding for an environment:
+
+1. Edit the variable in Railway dashboard (Project → service → Variables → select environment).
+2. Trigger a redeploy (`railway redeploy --service c123-live-mini --environment <env>` or push an empty commit; see "Forcing a redeploy" above).
+3. Verify the new value at the public URL.
+
+Local-dev override: copy `packages/client/.env.example` → `packages/client/.env.local` and edit, or pass inline like `VITE_APP_NAME="Foo" npx vite`.
+
 ---
 
 ## First-time bootstrap (after a fresh Railway deploy or DB reset)

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,0 +1,17 @@
+# c123-live-mini client — branding configuration
+#
+# All variables below are OPTIONAL. The values shown here are the built-in
+# defaults baked into the source — leaving them unset reproduces the original
+# ČSK Live deployment exactly.
+#
+# Vite reads `VITE_*` variables at BUILD TIME (`npm run build` / `vite build`),
+# so changing them on Railway requires a redeploy to take effect. See
+# `docs/RUNBOOK.md` → "Build-time client branding" for the operational notes.
+#
+# Local dev: copy this file to `.env.local` and edit, OR pass inline:
+#   VITE_APP_NAME="Ligový pohár" npx vite
+
+VITE_APP_NAME="ČSK Live"
+VITE_APP_SUBTITLE="Živé výsledky kanoistického slalomu"
+VITE_HOME_LINK="https://kanoe.cz"
+VITE_HOME_LINK_LABEL="Zpět na kanoe.cz"

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -16,6 +16,7 @@ const mockEvents = [
     endDate: '2026-02-06',
     discipline: null,
     status: 'running',
+    imageUrl: null,
   },
 ];
 
@@ -45,9 +46,18 @@ afterEach(() => {
 });
 
 describe('App', () => {
-  it('renders the app title in header', () => {
+  it('renders the app title in header and hero', () => {
     render(<App />);
-    expect(screen.getByText('ČSK Live')).toBeTruthy();
+    // Header (satellite) and HeroSection both render the branding app name,
+    // so there are at least two matches.
+    expect(screen.getAllByText('ČSK Live').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the homepage hero subtitle from branding defaults', () => {
+    render(<App />);
+    expect(
+      screen.getByText('Živé výsledky kanoistického slalomu')
+    ).toBeTruthy();
   });
 
   it('shows shared package version in footer', () => {
@@ -88,11 +98,11 @@ describe('App', () => {
     expect(container.querySelector('.csk-skeleton-card')).toBeTruthy();
   });
 
-  it('shows Czech section header', async () => {
+  it('groups running events under "Probíhá živě" status section', async () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText('Závody')).toBeTruthy();
+      expect(screen.getByText('Probíhá živě')).toBeTruthy();
     });
   });
 });

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -46,14 +46,14 @@ afterEach(() => {
 });
 
 describe('App', () => {
-  it('renders the app title in header and hero', () => {
+  it('renders the app name only in the satellite header (not duplicated in hero)', () => {
     render(<App />);
-    // Header (satellite) and HeroSection both render the branding app name,
-    // so there are at least two matches.
-    expect(screen.getAllByText('ČSK Live').length).toBeGreaterThanOrEqual(1);
+    // Hero promotes the subtitle/tagline to title to avoid duplicating
+    // appName above the fold — see EventListPage.tsx.
+    expect(screen.getAllByText('ČSK Live').length).toBe(1);
   });
 
-  it('renders the homepage hero subtitle from branding defaults', () => {
+  it('renders the tagline as the homepage hero title', () => {
     render(<App />);
     expect(
       screen.getByText('Živé výsledky kanoistického slalomu')

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,10 +4,16 @@ import { Route, Switch, Router } from 'wouter';
 import { useHashLocation } from 'wouter/use-hash-location';
 import { EventListPage } from './pages/EventListPage';
 import { EventDetailPage } from './pages/EventDetailPage';
+import { branding } from './config/branding';
 
 function App() {
   const headerContent = (
-    <Header variant="satellite" appName="ČSK Live" />
+    <Header
+      variant="satellite"
+      appName={branding.appName}
+      homeLink={branding.homeLink}
+      homeLinkLabel={branding.homeLinkLabel}
+    />
   );
 
   const footerContent = (

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -1,4 +1,5 @@
 import { Card, Badge, EmptyState, LiveIndicator } from '@czechcanoe/rvp-design-system';
+import type { PublicEventStatus } from '@c123-live-mini/shared';
 import type { EventListItem } from '../services/api';
 
 interface EventListProps {
@@ -6,38 +7,29 @@ interface EventListProps {
   onSelectEvent: (eventId: string) => void;
 }
 
-/**
- * Map event status to Badge variant
- */
-function getStatusVariant(status: string): 'success' | 'default' | 'info' {
+function getStatusVariant(
+  status: PublicEventStatus
+): 'success' | 'default' | 'info' {
   switch (status) {
     case 'running':
       return 'success';
     case 'finished':
     case 'official':
       return 'info';
-    default:
+    case 'startlist':
       return 'default';
   }
 }
 
-/**
- * Map event status to Czech label
- */
-function getStatusLabel(status: string): string {
+function getStatusLabel(status: PublicEventStatus): string {
   switch (status) {
     case 'running':
       return 'probíhá';
     case 'finished':
-      return 'dokončeno';
     case 'official':
       return 'dokončeno';
     case 'startlist':
       return 'startovní listina';
-    case 'draft':
-      return 'příprava';
-    default:
-      return status;
   }
 }
 
@@ -56,7 +48,7 @@ const dayMonthFormatter = new Intl.DateTimeFormat('cs-CZ', {
  * Format an event date or date range in Czech locale.
  *
  * - single day → "5. května 2026"
- * - range → "1.–3. května 2026"
+ * - range → "1. května – 3. května 2026"
  * - returns null when both inputs are missing or unparseable
  */
 function formatEventDate(
@@ -79,9 +71,6 @@ function formatEventDate(
   return `${dayMonthFormatter.format(start)} – ${dateFormatter.format(end)}`;
 }
 
-/**
- * Display a list of events using DS components
- */
 export function EventList({ events, onSelectEvent }: EventListProps) {
   if (events.length === 0) {
     return (
@@ -115,7 +104,8 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                 <img
                   src={event.imageUrl}
                   alt=""
-                  loading="lazy"
+                  width={64}
+                  height={64}
                   style={{
                     width: '64px',
                     height: '64px',

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -106,6 +106,8 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                   alt=""
                   width={64}
                   height={64}
+                  loading="lazy"
+                  decoding="async"
                   style={{
                     width: '64px',
                     height: '64px',

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -41,6 +41,44 @@ function getStatusLabel(status: string): string {
   }
 }
 
+const dateFormatter = new Intl.DateTimeFormat('cs-CZ', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+const dayMonthFormatter = new Intl.DateTimeFormat('cs-CZ', {
+  day: 'numeric',
+  month: 'long',
+});
+
+/**
+ * Format an event date or date range in Czech locale.
+ *
+ * - single day → "5. května 2026"
+ * - range → "1.–3. května 2026"
+ * - returns null when both inputs are missing or unparseable
+ */
+function formatEventDate(
+  startDate: string | null,
+  endDate: string | null
+): string | null {
+  if (!startDate) return null;
+  const start = new Date(startDate);
+  if (Number.isNaN(start.getTime())) return null;
+
+  if (!endDate || endDate === startDate) {
+    return dateFormatter.format(start);
+  }
+
+  const end = new Date(endDate);
+  if (Number.isNaN(end.getTime())) {
+    return dateFormatter.format(start);
+  }
+
+  return `${dayMonthFormatter.format(start)} – ${dateFormatter.format(end)}`;
+}
+
 /**
  * Display a list of events using DS components
  */
@@ -57,57 +95,88 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-      {events.map((event) => (
-        <Card
-          key={event.eventId}
-          clickable
-          onClick={() => onSelectEvent(event.eventId)}
-        >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              gap: '0.5rem',
-            }}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      {events.map((event) => {
+        const dateLabel = formatEventDate(event.startDate, event.endDate);
+        return (
+          <Card
+            key={event.eventId}
+            clickable
+            onClick={() => onSelectEvent(event.eventId)}
           >
-            <div>
-              <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
-                {event.mainTitle}
-              </div>
-              {event.subTitle && (
+            <div
+              style={{
+                display: 'flex',
+                gap: '1rem',
+                alignItems: 'flex-start',
+              }}
+            >
+              {event.imageUrl && (
+                <img
+                  src={event.imageUrl}
+                  alt=""
+                  loading="lazy"
+                  style={{
+                    width: '64px',
+                    height: '64px',
+                    flexShrink: 0,
+                    objectFit: 'cover',
+                    borderRadius: 'var(--csk-radius-md, 8px)',
+                  }}
+                />
+              )}
+              <div style={{ flex: 1, minWidth: 0 }}>
                 <div
                   style={{
-                    fontSize: '0.875rem',
-                    color: 'var(--csk-color-text-secondary)',
+                    fontSize: '1.125rem',
+                    fontWeight: 700,
+                    lineHeight: 1.3,
                     marginBottom: '0.25rem',
                   }}
                 >
-                  {event.subTitle}
+                  {event.mainTitle}
                 </div>
-              )}
+                {event.subTitle && (
+                  <div
+                    style={{
+                      fontSize: '0.875rem',
+                      color: 'var(--csk-color-text-secondary)',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    {event.subTitle}
+                  </div>
+                )}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '0.25rem 1rem',
+                    fontSize: '0.875rem',
+                    color: 'var(--csk-color-text-tertiary)',
+                  }}
+                >
+                  {event.location && <span>{event.location}</span>}
+                  {dateLabel && <span>{dateLabel}</span>}
+                </div>
+              </div>
               <div
                 style={{
                   display: 'flex',
-                  gap: '1rem',
-                  fontSize: '0.875rem',
-                  color: 'var(--csk-color-text-tertiary)',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  flexShrink: 0,
                 }}
               >
-                {event.location && <span>{event.location}</span>}
-                {event.startDate && <span>{event.startDate}</span>}
+                {event.status === 'running' && <LiveIndicator />}
+                <Badge variant={getStatusVariant(event.status)}>
+                  {getStatusLabel(event.status)}
+                </Badge>
               </div>
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              {event.status === 'running' && <LiveIndicator />}
-              <Badge variant={getStatusVariant(event.status)}>
-                {getStatusLabel(event.status)}
-              </Badge>
-            </div>
-          </div>
-        </Card>
-      ))}
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/packages/client/src/config/branding.ts
+++ b/packages/client/src/config/branding.ts
@@ -15,10 +15,13 @@ export interface Branding {
   homeLinkLabel: string;
 }
 
+// Use `||` (not `??`) so an empty-string value entered in the Railway UI
+// falls back to the default — clearing a variable without deleting it would
+// otherwise produce a blank header / hero with no warning.
 export const branding: Branding = {
-  appName: import.meta.env.VITE_APP_NAME ?? 'ČSK Live',
+  appName: import.meta.env.VITE_APP_NAME || 'ČSK Live',
   appSubtitle:
-    import.meta.env.VITE_APP_SUBTITLE ?? 'Živé výsledky kanoistického slalomu',
-  homeLink: import.meta.env.VITE_HOME_LINK ?? 'https://kanoe.cz',
-  homeLinkLabel: import.meta.env.VITE_HOME_LINK_LABEL ?? 'Zpět na kanoe.cz',
+    import.meta.env.VITE_APP_SUBTITLE || 'Živé výsledky kanoistického slalomu',
+  homeLink: import.meta.env.VITE_HOME_LINK || 'https://kanoe.cz',
+  homeLinkLabel: import.meta.env.VITE_HOME_LINK_LABEL || 'Zpět na kanoe.cz',
 };

--- a/packages/client/src/config/branding.ts
+++ b/packages/client/src/config/branding.ts
@@ -1,0 +1,43 @@
+/// <reference types="vite/client" />
+
+/**
+ * Branding configuration for the c123-live-mini client.
+ *
+ * Values are read from build-time `VITE_*` environment variables, with
+ * defaults that match the original ČSK Live deployment so unset variables
+ * cause no visible change.
+ *
+ * To rebrand a deployment, set the corresponding `VITE_*` variables in the
+ * Railway project (build phase) and trigger a redeploy. See
+ * `packages/client/.env.example` and `docs/RUNBOOK.md` for the full list.
+ */
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME?: string;
+  readonly VITE_APP_SUBTITLE?: string;
+  readonly VITE_HOME_LINK?: string;
+  readonly VITE_HOME_LINK_LABEL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+export interface Branding {
+  /** Main application name shown in the header and homepage hero. */
+  appName: string;
+  /** Subtitle shown under the app name in the homepage hero. */
+  appSubtitle: string;
+  /** URL of the parent site the satellite header links back to. */
+  homeLink: string;
+  /** Label of the back link in the satellite header. */
+  homeLinkLabel: string;
+}
+
+export const branding: Branding = {
+  appName: import.meta.env.VITE_APP_NAME ?? 'ČSK Live',
+  appSubtitle:
+    import.meta.env.VITE_APP_SUBTITLE ?? 'Živé výsledky kanoistického slalomu',
+  homeLink: import.meta.env.VITE_HOME_LINK ?? 'https://kanoe.cz',
+  homeLinkLabel: import.meta.env.VITE_HOME_LINK_LABEL ?? 'Zpět na kanoe.cz',
+};

--- a/packages/client/src/config/branding.ts
+++ b/packages/client/src/config/branding.ts
@@ -1,36 +1,17 @@
-/// <reference types="vite/client" />
-
 /**
  * Branding configuration for the c123-live-mini client.
  *
- * Values are read from build-time `VITE_*` environment variables, with
- * defaults that match the original ČSK Live deployment so unset variables
- * cause no visible change.
- *
- * To rebrand a deployment, set the corresponding `VITE_*` variables in the
+ * Values come from build-time `VITE_*` env vars, with defaults that match
+ * the original ČSK Live deployment so unset variables cause no visible
+ * change. To rebrand a deployment, set the corresponding variables in the
  * Railway project (build phase) and trigger a redeploy. See
  * `packages/client/.env.example` and `docs/RUNBOOK.md` for the full list.
  */
 
-interface ImportMetaEnv {
-  readonly VITE_APP_NAME?: string;
-  readonly VITE_APP_SUBTITLE?: string;
-  readonly VITE_HOME_LINK?: string;
-  readonly VITE_HOME_LINK_LABEL?: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-
 export interface Branding {
-  /** Main application name shown in the header and homepage hero. */
   appName: string;
-  /** Subtitle shown under the app name in the homepage hero. */
   appSubtitle: string;
-  /** URL of the parent site the satellite header links back to. */
   homeLink: string;
-  /** Label of the back link in the satellite header. */
   homeLinkLabel: string;
 }
 

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -84,11 +84,15 @@ export function EventListPage() {
 
   return (
     <>
+      {/*
+        The satellite Header already shows `branding.appName`. Use the
+        tagline as the hero title so we don't repeat the brand name above
+        the fold on mobile (review feedback on #134).
+      */}
       <HeroSection
         variant="minimal"
         section="generic"
-        title={branding.appName}
-        subtitle={branding.appSubtitle}
+        title={branding.appSubtitle}
         meshBackground
         wave
       />

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
+  HeroSection,
   SectionHeader,
   SkeletonCard,
   Card,
@@ -9,8 +10,37 @@ import {
 import { useLocation } from 'wouter';
 import { getEvents, ApiError, type EventListItem } from '../services/api';
 import { EventList } from '../components/EventList';
+import { branding } from '../config/branding';
 
 type LoadingState = 'idle' | 'loading' | 'success' | 'error';
+
+interface EventGroups {
+  running: EventListItem[];
+  upcoming: EventListItem[];
+  finished: EventListItem[];
+}
+
+function groupEventsByStatus(events: EventListItem[]): EventGroups {
+  const groups: EventGroups = { running: [], upcoming: [], finished: [] };
+  for (const event of events) {
+    switch (event.status) {
+      case 'running':
+        groups.running.push(event);
+        break;
+      case 'startlist':
+        groups.upcoming.push(event);
+        break;
+      case 'finished':
+      case 'official':
+        groups.finished.push(event);
+        break;
+      default:
+        // draft and unknown statuses are excluded from the public list
+        break;
+    }
+  }
+  return groups;
+}
 
 export function EventListPage() {
   const [events, setEvents] = useState<EventListItem[]>([]);
@@ -46,9 +76,19 @@ export function EventListPage() {
     [navigate]
   );
 
+  const groups = useMemo(() => groupEventsByStatus(events), [events]);
+  const hasAnyEvents = events.length > 0;
+
   return (
-    <section>
-      <SectionHeader title="Závody" />
+    <>
+      <HeroSection
+        variant="minimal"
+        section="generic"
+        title={branding.appName}
+        subtitle={branding.appSubtitle}
+        meshBackground
+        wave
+      />
 
       {state === 'loading' && <SkeletonCard />}
 
@@ -57,19 +97,52 @@ export function EventListPage() {
           <EmptyState
             title="Chyba připojení"
             description={error ?? 'Nepodařilo se připojit k serveru'}
-            action={
-              <Button onClick={fetchEvents}>Zkusit znovu</Button>
-            }
+            action={<Button onClick={fetchEvents}>Zkusit znovu</Button>}
           />
         </Card>
       )}
 
-      {state === 'success' && (
-        <EventList
-          events={events}
-          onSelectEvent={handleSelectEvent}
-        />
+      {state === 'success' && !hasAnyEvents && (
+        <EventList events={[]} onSelectEvent={handleSelectEvent} />
       )}
-    </section>
+
+      {state === 'success' && hasAnyEvents && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1.5rem',
+          }}
+        >
+          {groups.running.length > 0 && (
+            <section>
+              <SectionHeader title="Probíhá živě" />
+              <EventList
+                events={groups.running}
+                onSelectEvent={handleSelectEvent}
+              />
+            </section>
+          )}
+          {groups.upcoming.length > 0 && (
+            <section>
+              <SectionHeader title="Nadcházející" />
+              <EventList
+                events={groups.upcoming}
+                onSelectEvent={handleSelectEvent}
+              />
+            </section>
+          )}
+          {groups.finished.length > 0 && (
+            <section>
+              <SectionHeader title="Skončené" />
+              <EventList
+                events={groups.finished}
+                onSelectEvent={handleSelectEvent}
+              />
+            </section>
+          )}
+        </div>
+      )}
+    </>
   );
 }

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -20,6 +20,12 @@ interface EventGroups {
   finished: EventListItem[];
 }
 
+const STATUS_SECTIONS: Array<{ key: keyof EventGroups; title: string }> = [
+  { key: 'running', title: 'Probíhá živě' },
+  { key: 'upcoming', title: 'Nadcházející' },
+  { key: 'finished', title: 'Skončené' },
+];
+
 function groupEventsByStatus(events: EventListItem[]): EventGroups {
   const groups: EventGroups = { running: [], upcoming: [], finished: [] };
   for (const event of events) {
@@ -33,9 +39,6 @@ function groupEventsByStatus(events: EventListItem[]): EventGroups {
       case 'finished':
       case 'official':
         groups.finished.push(event);
-        break;
-      default:
-        // draft and unknown statuses are excluded from the public list
         break;
     }
   }
@@ -103,7 +106,12 @@ export function EventListPage() {
       )}
 
       {state === 'success' && !hasAnyEvents && (
-        <EventList events={[]} onSelectEvent={handleSelectEvent} />
+        <Card>
+          <EmptyState
+            title="Žádné závody nejsou k dispozici"
+            description="Momentálně nejsou vypsány žádné závody."
+          />
+        </Card>
       )}
 
       {state === 'success' && hasAnyEvents && (
@@ -114,32 +122,16 @@ export function EventListPage() {
             gap: '1.5rem',
           }}
         >
-          {groups.running.length > 0 && (
-            <section>
-              <SectionHeader title="Probíhá živě" />
-              <EventList
-                events={groups.running}
-                onSelectEvent={handleSelectEvent}
-              />
-            </section>
-          )}
-          {groups.upcoming.length > 0 && (
-            <section>
-              <SectionHeader title="Nadcházející" />
-              <EventList
-                events={groups.upcoming}
-                onSelectEvent={handleSelectEvent}
-              />
-            </section>
-          )}
-          {groups.finished.length > 0 && (
-            <section>
-              <SectionHeader title="Skončené" />
-              <EventList
-                events={groups.finished}
-                onSelectEvent={handleSelectEvent}
-              />
-            </section>
+          {STATUS_SECTIONS.map(({ key, title }) =>
+            groups[key].length > 0 ? (
+              <section key={key}>
+                <SectionHeader title={title} />
+                <EventList
+                  events={groups[key]}
+                  onSelectEvent={handleSelectEvent}
+                />
+              </section>
+            ) : null
           )}
         </div>
       )}

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME?: string;
+  readonly VITE_APP_SUBTITLE?: string;
+  readonly VITE_HOME_LINK?: string;
+  readonly VITE_HOME_LINK_LABEL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/railway.toml
+++ b/railway.toml
@@ -10,6 +10,13 @@
 #   @czechcanoe/rvp-design-system. Set as a Railway project variable,
 #   marked for the build phase. See .npmrc.example for details.
 #
+# Build-time client branding (optional, all have defaults — see
+# packages/client/.env.example and docs/RUNBOOK.md):
+#   VITE_APP_NAME           — header + hero title
+#   VITE_APP_SUBTITLE       — hero subtitle
+#   VITE_HOME_LINK          — satellite header back-link URL
+#   VITE_HOME_LINK_LABEL    — satellite header back-link text
+#
 # Runtime env vars (set per environment in Railway):
 #   NODE_ENV=production
 #   DATABASE_PATH=/data/live-mini.db   (must point to mounted volume)


### PR DESCRIPTION
Closes #120

## Summary

Two issues from #120 addressed in one PR:

1. **Configurable header** — `Header` (satellite variant) was hardcoded to ČSK Live + kanoe.cz back-link. Now reads from build-time `VITE_*` env vars (`VITE_APP_NAME`, `VITE_APP_SUBTITLE`, `VITE_HOME_LINK`, `VITE_HOME_LINK_LABEL`) with safe defaults that match the original deployment, so unset variables are zero-config (no regression).
2. **Homepage hero + grouping** — `EventListPage` now leads with a `HeroSection` (variant=`minimal`, mesh background + wave divider) and groups events into three status sections (`Probíhá živě` / `Nadcházející` / `Skončené`) using `SectionHeader` from the design system. Empty groups are not rendered.

Bonus polish on `EventList` cards: bigger 1.125rem/700 title, optional 64×64 image thumbnail when `imageUrl` is present (server already returns it), humanized cs-CZ date / date-range via `Intl.DateTimeFormat` instead of raw ISO.

### Approach

- **Build-time `VITE_*` ENV** chosen over a runtime config endpoint — branding changes maybe once a year, so a Railway redeploy is acceptable, and the SPA boots with the values already baked in (no flash of stale defaults, no extra fetch).
- **Reuse over reinvention** — `Header.appName/homeLink/homeLinkLabel` and `HeroSection` are already in `@czechcanoe/rvp-design-system`. No new components, no DS modifications.
- One central `branding` module (`packages/client/src/config/branding.ts`) keeps `import.meta.env` access in a single place. Type augmentation lives in a proper ambient `vite-env.d.ts`.

### Files changed

| File | Why |
|---|---|
| `packages/client/src/config/branding.ts` (new) | central branding object with `VITE_*` reads + defaults |
| `packages/client/src/vite-env.d.ts` (new) | ambient `ImportMetaEnv` augmentation for the new vars |
| `packages/client/src/App.tsx` | thread branding into `Header` |
| `packages/client/src/pages/EventListPage.tsx` | `HeroSection`, `useMemo` grouping, data-driven status sections |
| `packages/client/src/components/EventList.tsx` | larger title, image thumbnail, `Intl` date range, `PublicEventStatus`-typed mappers |
| `packages/client/src/App.test.tsx` | updated expectations (multi-match `ČSK Live`, hero subtitle, status section header) |
| `packages/client/.env.example` (new) | dev documentation for the new vars |
| `docs/RUNBOOK.md` | new "Build-time client branding" section + workflow |
| `railway.toml` | header comment lists the new build-time vars |

### Test plan

- [x] `npx vitest run` — 169 passed (16 files)
- [x] `npx tsc --noEmit -p packages/client/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p packages/server/tsconfig.json` — clean (server untouched, sanity check)
- [x] Local default build → grep `dist/assets/*.js` for `ČSK Live` / `Zpět na kanoe.cz` / `kanoe.cz` / `Živé výsledky kanoistického slalomu` — all present
- [x] Local custom build with `VITE_APP_NAME="Test Liga" VITE_APP_SUBTITLE="Custom" VITE_HOME_LINK="https://example.com" VITE_HOME_LINK_LABEL="Custom back" npx vite build` → all four custom values baked into the bundle, ČSK defaults gone (only the DS internal default for `homeLink` remains, which is unused since we always pass a value)
- [ ] Staging deploy: visit https://c123-live-mini-staging.up.railway.app/, verify defaults render unchanged when `VITE_*` are not yet set
- [ ] Set `VITE_APP_NAME` on staging Railway env → trigger redeploy → verify both header and hero update
- [ ] Same on production after staging is green
- [ ] Mobile viewport (iPhone 12) — confirm `HeroSection minimal` does not eat more than ~140 px above the event list

### Side note (out of scope, follow-up)

Per-screenshot review: `<LiveIndicator />` in `EventList.tsx` renders as a static gray dot, not the pulsing red live state. Probably a missing prop on the DS component. Will file a separate issue once this lands.