### PR TITLE
feat(client): polish homepage visual quality (#120 follow-up)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -245,8 +245,9 @@ These variables are read by Vite **during the Nixpacks build phase** (`vite buil
 
 | Variable | Default | What it controls |
 |---|---|---|
-| `VITE_APP_NAME` | `ČSK Live` | Header title (satellite breadcrumb) **and** homepage hero title |
-| `VITE_APP_SUBTITLE` | `Živé výsledky kanoistického slalomu` | Homepage hero subtitle |
+| `VITE_APP_NAME` | `ČSK Live` | Header title (satellite breadcrumb) |
+| `VITE_APP_SUBTITLE` | `Živé výsledky kanoistického slalomu` | Homepage hero title |
+| `VITE_APP_SUBTITLE_ACCENT` | `kanoistického slalomu` | Substring of the subtitle rendered in the hero accent colour (light blue on the dv section). Must literally appear inside `VITE_APP_SUBTITLE`; otherwise the hero shows the full title in one colour. Set to a non-substring value to effectively disable the accent. |
 | `VITE_HOME_LINK` | `https://kanoe.cz` | Satellite header back-link URL |
 | `VITE_HOME_LINK_LABEL` | `Zpět na kanoe.cz` | Satellite header back-link text |
 

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -13,5 +13,10 @@
 
 VITE_APP_NAME="ČSK Live"
 VITE_APP_SUBTITLE="Živé výsledky kanoistického slalomu"
+# Optional: substring of VITE_APP_SUBTITLE rendered in the hero accent
+# colour (light blue on the dv section). Must literally appear inside
+# VITE_APP_SUBTITLE — otherwise the hero shows the whole title in one
+# colour. Leave commented out to disable the accent.
+VITE_APP_SUBTITLE_ACCENT="kanoistického slalomu"
 VITE_HOME_LINK="https://kanoe.cz"
 VITE_HOME_LINK_LABEL="Zpět na kanoe.cz"

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -55,9 +55,11 @@ describe('App', () => {
 
   it('renders the tagline as the homepage hero title', () => {
     render(<App />);
-    expect(
-      screen.getByText('Živé výsledky kanoistického slalomu')
-    ).toBeTruthy();
+    // The hero uses `titleAccent` which splits the title into multiple
+    // elements (a leading span + an accent span), so we can't match the
+    // whole string with a string-based query.
+    expect(screen.getByText(/Živé výsledky/)).toBeTruthy();
+    expect(screen.getByText(/kanoistického slalomu/)).toBeTruthy();
   });
 
   it('shows shared package version in footer', () => {

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -5,7 +5,8 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import App from './App';
 
-// Mock data — updated for Feature #6 types (no id, no disId, uses raceType)
+// Mock data — two events in different status groups so the homepage
+// renders multiple sections (and therefore the section headings).
 const mockEvents = [
   {
     eventId: 'demo-2026',
@@ -16,6 +17,17 @@ const mockEvents = [
     endDate: '2026-02-06',
     discipline: null,
     status: 'running',
+    imageUrl: null,
+  },
+  {
+    eventId: 'demo-upcoming',
+    mainTitle: 'Upcoming Event',
+    subTitle: null,
+    location: 'Brno',
+    startDate: '2026-05-01',
+    endDate: '2026-05-03',
+    discipline: null,
+    status: 'startlist',
     imageUrl: null,
   },
 ];

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -31,7 +31,12 @@ function App() {
 
   return (
     <Router hook={useHashLocation}>
-      <PageLayout variant="satellite" header={headerContent} footer={footerContent}>
+      <PageLayout
+        variant="satellite"
+        maxWidth="md"
+        header={headerContent}
+        footer={footerContent}
+      >
         <Switch>
           <Route path="/">
             <EventListPage />

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -1,18 +1,29 @@
-import { Card, Badge, EmptyState, LiveIndicator } from '@czechcanoe/rvp-design-system';
+import {
+  Card,
+  Badge,
+  EmptyState,
+  LiveIndicator,
+  Icon,
+} from '@czechcanoe/rvp-design-system';
 import type { PublicEventStatus } from '@c123-live-mini/shared';
 import type { EventListItem } from '../services/api';
 
 interface EventListProps {
   events: EventListItem[];
   onSelectEvent: (eventId: string) => void;
+  /**
+   * Highlight cards in this list as live/important
+   * (adds energy glow + elevated card variant).
+   */
+  emphasised?: boolean;
 }
 
 function getStatusVariant(
   status: PublicEventStatus
-): 'success' | 'default' | 'info' {
+): 'success' | 'default' | 'info' | 'energy' {
   switch (status) {
     case 'running':
-      return 'success';
+      return 'energy';
     case 'finished':
     case 'official':
       return 'info';
@@ -71,7 +82,11 @@ function formatEventDate(
   return `${dayMonthFormatter.format(start)} – ${dateFormatter.format(end)}`;
 }
 
-export function EventList({ events, onSelectEvent }: EventListProps) {
+export function EventList({
+  events,
+  onSelectEvent,
+  emphasised = false,
+}: EventListProps) {
   if (events.length === 0) {
     return (
       <Card>
@@ -87,43 +102,47 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
       {events.map((event) => {
         const dateLabel = formatEventDate(event.startDate, event.endDate);
+        const isRunning = event.status === 'running';
         return (
           <Card
             key={event.eventId}
+            variant={emphasised ? 'elevated' : 'surface'}
+            padding="md"
             clickable
             onClick={() => onSelectEvent(event.eventId)}
+            className={emphasised ? 'csk-energy-glow--sm' : undefined}
           >
             <div
               style={{
                 display: 'flex',
                 gap: '1rem',
-                alignItems: 'flex-start',
+                alignItems: 'center',
               }}
             >
               {event.imageUrl && (
                 <img
                   src={event.imageUrl}
                   alt=""
-                  width={64}
-                  height={64}
+                  width={72}
+                  height={72}
                   loading="lazy"
                   decoding="async"
                   style={{
-                    width: '64px',
-                    height: '64px',
+                    width: '72px',
+                    height: '72px',
                     flexShrink: 0,
                     objectFit: 'cover',
-                    borderRadius: 'var(--csk-radius-md, 8px)',
+                    borderRadius: 'var(--csk-radius-md, 12px)',
                   }}
                 />
               )}
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div
                   style={{
-                    fontSize: '1.125rem',
+                    fontSize: emphasised ? '1.25rem' : '1.125rem',
                     fontWeight: 700,
-                    lineHeight: 1.3,
-                    marginBottom: '0.25rem',
+                    lineHeight: 1.25,
+                    marginBottom: '0.375rem',
                   }}
                 >
                   {event.mainTitle}
@@ -133,7 +152,7 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                     style={{
                       fontSize: '0.875rem',
                       color: 'var(--csk-color-text-secondary)',
-                      marginBottom: '0.25rem',
+                      marginBottom: '0.375rem',
                     }}
                   >
                     {event.subTitle}
@@ -143,13 +162,35 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                   style={{
                     display: 'flex',
                     flexWrap: 'wrap',
-                    gap: '0.25rem 1rem',
+                    gap: '0.375rem 1rem',
                     fontSize: '0.875rem',
                     color: 'var(--csk-color-text-tertiary)',
                   }}
                 >
-                  {event.location && <span>{event.location}</span>}
-                  {dateLabel && <span>{dateLabel}</span>}
+                  {event.location && (
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.375rem',
+                      }}
+                    >
+                      <Icon name="map-pin" size="sm" aria-label="Místo" />
+                      {event.location}
+                    </span>
+                  )}
+                  {dateLabel && (
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.375rem',
+                      }}
+                    >
+                      <Icon name="calendar" size="sm" aria-label="Datum" />
+                      {dateLabel}
+                    </span>
+                  )}
                 </div>
               </div>
               <div
@@ -160,10 +201,27 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                   flexShrink: 0,
                 }}
               >
-                {event.status === 'running' && <LiveIndicator />}
-                <Badge variant={getStatusVariant(event.status)}>
+                {isRunning && (
+                  <LiveIndicator
+                    variant="live"
+                    size="sm"
+                    energyGlow
+                    pulse
+                  />
+                )}
+                <Badge
+                  variant={getStatusVariant(event.status)}
+                  size="md"
+                  glow={isRunning}
+                >
                   {getStatusLabel(event.status)}
                 </Badge>
+                <Icon
+                  name="chevron-right"
+                  size="md"
+                  aria-hidden
+                  className="csk-color-on-surface-muted"
+                />
               </div>
             </div>
           </Card>

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -106,11 +106,10 @@ export function EventList({
         return (
           <Card
             key={event.eventId}
-            variant={emphasised ? 'elevated' : 'surface'}
+            variant={emphasised ? 'aesthetic' : 'elevated'}
             padding="md"
             clickable
             onClick={() => onSelectEvent(event.eventId)}
-            className={emphasised ? 'csk-energy-glow--sm' : undefined}
           >
             <div
               style={{

--- a/packages/client/src/config/branding.ts
+++ b/packages/client/src/config/branding.ts
@@ -11,6 +11,13 @@
 export interface Branding {
   appName: string;
   appSubtitle: string;
+  /**
+   * Optional substring of `appSubtitle` to render in the hero accent color
+   * (light blue per the `dv` section). Must literally appear inside
+   * `appSubtitle` — otherwise the hero just shows the full title in one
+   * colour. Leave unset to disable the accent.
+   */
+  appSubtitleAccent?: string;
   homeLink: string;
   homeLinkLabel: string;
 }
@@ -22,6 +29,8 @@ export const branding: Branding = {
   appName: import.meta.env.VITE_APP_NAME || 'ČSK Live',
   appSubtitle:
     import.meta.env.VITE_APP_SUBTITLE || 'Živé výsledky kanoistického slalomu',
+  appSubtitleAccent:
+    import.meta.env.VITE_APP_SUBTITLE_ACCENT || 'kanoistického slalomu',
   homeLink: import.meta.env.VITE_HOME_LINK || 'https://kanoe.cz',
   homeLinkLabel: import.meta.env.VITE_HOME_LINK_LABEL || 'Zpět na kanoe.cz',
 };

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -116,9 +116,6 @@ export function EventListPage() {
           flexDirection: 'column',
           gap: '2rem',
           paddingBlock: '1.5rem',
-          maxWidth: '760px',
-          marginInline: 'auto',
-          width: '100%',
         }}
       >
         {state === 'loading' && <SkeletonCard />}

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -116,6 +116,9 @@ export function EventListPage() {
           flexDirection: 'column',
           gap: '2rem',
           paddingBlock: '1.5rem',
+          maxWidth: '760px',
+          marginInline: 'auto',
+          width: '100%',
         }}
       >
         {state === 'loading' && <SkeletonCard />}
@@ -156,7 +159,6 @@ export function EventListPage() {
                         size="md"
                         energyGlow
                         pulse
-                        label="LIVE"
                       />
                     ) : (
                       <Badge variant="default" size="sm">

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -114,8 +114,8 @@ export function EventListPage() {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: '2rem',
-          paddingBlock: '1.5rem',
+          gap: '1.75rem',
+          paddingBlock: '1.25rem',
         }}
       >
         {state === 'loading' && <SkeletonCard />}

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -34,6 +34,19 @@ const STATUS_SECTIONS: StatusSectionConfig[] = [
   { key: 'finished', title: 'Skončené' },
 ];
 
+/** Czech pluralization for "závod" (race). */
+function raceCountLabel(count: number): string {
+  if (count === 1) return '1 závod';
+  if (count >= 2 && count <= 4) return `${count} závody`;
+  return `${count} závodů`;
+}
+
+const SECTION_DESCRIPTIONS: Record<keyof EventGroups, (n: number) => string> = {
+  running: (n) => `${raceCountLabel(n)} běží právě teď`,
+  upcoming: (n) => `${raceCountLabel(n)} v nejbližší době`,
+  finished: (n) => `${raceCountLabel(n)} už máme za sebou`,
+};
+
 function groupEventsByStatus(events: EventListItem[]): EventGroups {
   const groups: EventGroups = { running: [], upcoming: [], finished: [] };
   for (const event of events) {
@@ -111,11 +124,13 @@ export function EventListPage() {
       />
 
       <div
+        className="csk-mesh-bg--subtle"
         style={{
           display: 'flex',
           flexDirection: 'column',
           gap: '1.75rem',
-          paddingBlock: '1.25rem',
+          paddingBlock: '1.5rem',
+          borderRadius: '12px',
         }}
       >
         {state === 'loading' && <SkeletonCard />}
@@ -150,6 +165,7 @@ export function EventListPage() {
                 <SectionHeader
                   title={title}
                   size={isLive ? 'lg' : 'md'}
+                  description={SECTION_DESCRIPTIONS[key](groups[key].length)}
                   badge={
                     isLive ? (
                       <LiveIndicator
@@ -158,11 +174,7 @@ export function EventListPage() {
                         energyGlow
                         pulse
                       />
-                    ) : (
-                      <Badge variant="default" size="sm">
-                        {groups[key].length}
-                      </Badge>
-                    )
+                    ) : undefined
                   }
                 />
                 <EventList

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -176,7 +176,7 @@ export function EventListPage() {
         variant="compact"
         section="dv"
         title={branding.appSubtitle}
-        titleAccent="kanoistického slalomu"
+        titleAccent={branding.appSubtitleAccent}
         meshBackground
         patternOverlay
         badges={

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -6,6 +6,8 @@ import {
   Card,
   EmptyState,
   Button,
+  Badge,
+  LiveIndicator,
 } from '@czechcanoe/rvp-design-system';
 import { useLocation } from 'wouter';
 import { getEvents, ApiError, type EventListItem } from '../services/api';
@@ -20,8 +22,14 @@ interface EventGroups {
   finished: EventListItem[];
 }
 
-const STATUS_SECTIONS: Array<{ key: keyof EventGroups; title: string }> = [
-  { key: 'running', title: 'Probíhá živě' },
+interface StatusSectionConfig {
+  key: keyof EventGroups;
+  title: string;
+  isLive?: boolean;
+}
+
+const STATUS_SECTIONS: StatusSectionConfig[] = [
+  { key: 'running', title: 'Probíhá živě', isLive: true },
   { key: 'upcoming', title: 'Nadcházející' },
   { key: 'finished', title: 'Skončené' },
 ];
@@ -81,64 +89,91 @@ export function EventListPage() {
 
   const groups = useMemo(() => groupEventsByStatus(events), [events]);
   const hasAnyEvents = events.length > 0;
+  const liveCount = groups.running.length;
 
   return (
     <>
-      {/*
-        The satellite Header already shows `branding.appName`. Use the
-        tagline as the hero title so we don't repeat the brand name above
-        the fold on mobile (review feedback on #134).
-      */}
       <HeroSection
-        variant="minimal"
-        section="generic"
+        variant="compact"
+        section="dv"
         title={branding.appSubtitle}
         meshBackground
+        patternOverlay
         wave
+        badges={
+          liveCount > 0 ? (
+            <Badge variant="energy" size="lg" glow>
+              LIVE • {liveCount}
+            </Badge>
+          ) : undefined
+        }
+        className="csk-reveal csk-reveal-1"
       />
 
-      {state === 'loading' && <SkeletonCard />}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2rem',
+          paddingBlock: '1.5rem',
+        }}
+      >
+        {state === 'loading' && <SkeletonCard />}
 
-      {state === 'error' && (
-        <Card>
-          <EmptyState
-            title="Chyba připojení"
-            description={error ?? 'Nepodařilo se připojit k serveru'}
-            action={<Button onClick={fetchEvents}>Zkusit znovu</Button>}
-          />
-        </Card>
-      )}
+        {state === 'error' && (
+          <Card>
+            <EmptyState
+              title="Chyba připojení"
+              description={error ?? 'Nepodařilo se připojit k serveru'}
+              action={<Button onClick={fetchEvents}>Zkusit znovu</Button>}
+            />
+          </Card>
+        )}
 
-      {state === 'success' && !hasAnyEvents && (
-        <Card>
-          <EmptyState
-            title="Žádné závody nejsou k dispozici"
-            description="Momentálně nejsou vypsány žádné závody."
-          />
-        </Card>
-      )}
+        {state === 'success' && !hasAnyEvents && (
+          <Card>
+            <EmptyState
+              title="Žádné závody nejsou k dispozici"
+              description="Momentálně nejsou vypsány žádné závody."
+            />
+          </Card>
+        )}
 
-      {state === 'success' && hasAnyEvents && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '1.5rem',
-          }}
-        >
-          {STATUS_SECTIONS.map(({ key, title }) =>
+        {state === 'success' &&
+          hasAnyEvents &&
+          STATUS_SECTIONS.map(({ key, title, isLive }, idx) =>
             groups[key].length > 0 ? (
-              <section key={key}>
-                <SectionHeader title={title} />
+              <section
+                key={key}
+                className={`csk-reveal csk-reveal-${idx + 2}`}
+              >
+                <SectionHeader
+                  title={title}
+                  badge={
+                    isLive ? (
+                      <LiveIndicator
+                        variant="live"
+                        size="md"
+                        energyGlow
+                        pulse
+                        label="LIVE"
+                      />
+                    ) : (
+                      <Badge variant="default" size="sm">
+                        {groups[key].length}
+                      </Badge>
+                    )
+                  }
+                />
                 <EventList
                   events={groups[key]}
                   onSelectEvent={handleSelectEvent}
+                  emphasised={isLive}
                 />
               </section>
             ) : null
           )}
-        </div>
-      )}
+      </div>
     </>
   );
 }

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   HeroSection,
-  SectionHeader,
   SkeletonCard,
   Card,
   EmptyState,
@@ -66,6 +65,66 @@ function groupEventsByStatus(events: EventListItem[]): EventGroups {
   return groups;
 }
 
+interface SectionHeadingProps {
+  title: string;
+  description: string;
+  isLive?: boolean;
+}
+
+/**
+ * Custom section heading with stronger visual hierarchy than the
+ * design-system `SectionHeader` (which is intentionally subtle).
+ *
+ * Live sections get a coral accent bar, an inline pulsing live dot,
+ * and a slightly larger title — so spectators immediately spot the
+ * "Probíhá živě" block when they land on the page.
+ */
+function SectionHeading({ title, description, isLive }: SectionHeadingProps) {
+  return (
+    <header
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.25rem',
+        marginBottom: '0.875rem',
+        paddingLeft: isLive ? '0.875rem' : 0,
+        borderLeft: isLive
+          ? '4px solid var(--color-energy-500, #f97316)'
+          : undefined,
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          fontSize: isLive ? '1.5rem' : '1.25rem',
+          fontWeight: 800,
+          letterSpacing: '-0.01em',
+          lineHeight: 1.2,
+          color: 'var(--csk-color-on-surface, var(--color-text-primary))',
+        }}
+      >
+        {title}
+        {isLive && (
+          <LiveIndicator variant="live" size="md" energyGlow pulse />
+        )}
+      </h2>
+      <p
+        style={{
+          margin: 0,
+          fontSize: '0.9375rem',
+          color:
+            'var(--csk-color-on-surface-muted, var(--color-text-secondary))',
+        }}
+      >
+        {description}
+      </p>
+    </header>
+  );
+}
+
 export function EventListPage() {
   const [events, setEvents] = useState<EventListItem[]>([]);
   const [state, setState] = useState<LoadingState>('idle');
@@ -103,6 +162,13 @@ export function EventListPage() {
   const groups = useMemo(() => groupEventsByStatus(events), [events]);
   const hasAnyEvents = events.length > 0;
   const liveCount = groups.running.length;
+  const visibleSectionCount = STATUS_SECTIONS.filter(
+    (s) => groups[s.key].length > 0
+  ).length;
+  // When only a single status group is non-empty, the section heading is
+  // redundant — the hero badge + the cards' own status badges already
+  // tell the user what they're looking at. Skip headings in that case.
+  const showHeadings = visibleSectionCount > 1;
 
   return (
     <>
@@ -128,9 +194,9 @@ export function EventListPage() {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: '1.75rem',
-          paddingBlock: '1.5rem',
-          borderRadius: '12px',
+          gap: '2.25rem',
+          paddingBlock: '2rem',
+          paddingInline: '1rem',
         }}
       >
         {state === 'loading' && <SkeletonCard />}
@@ -162,21 +228,13 @@ export function EventListPage() {
                 key={key}
                 className={`csk-reveal csk-reveal-${idx + 2}`}
               >
-                <SectionHeader
-                  title={title}
-                  size={isLive ? 'lg' : 'md'}
-                  description={SECTION_DESCRIPTIONS[key](groups[key].length)}
-                  badge={
-                    isLive ? (
-                      <LiveIndicator
-                        variant="live"
-                        size="lg"
-                        energyGlow
-                        pulse
-                      />
-                    ) : undefined
-                  }
-                />
+                {showHeadings && (
+                  <SectionHeading
+                    title={title}
+                    description={SECTION_DESCRIPTIONS[key](groups[key].length)}
+                    isLive={isLive}
+                  />
+                )}
                 <EventList
                   events={groups[key]}
                   onSelectEvent={handleSelectEvent}

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -97,9 +97,9 @@ export function EventListPage() {
         variant="compact"
         section="dv"
         title={branding.appSubtitle}
+        titleAccent="kanoistického slalomu"
         meshBackground
         patternOverlay
-        wave
         badges={
           liveCount > 0 ? (
             <Badge variant="energy" size="lg" glow>
@@ -149,11 +149,12 @@ export function EventListPage() {
               >
                 <SectionHeader
                   title={title}
+                  size={isLive ? 'lg' : 'md'}
                   badge={
                     isLive ? (
                       <LiveIndicator
                         variant="live"
-                        size="md"
+                        size="lg"
                         energyGlow
                         pulse
                       />

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_APP_NAME?: string;
   readonly VITE_APP_SUBTITLE?: string;
+  readonly VITE_APP_SUBTITLE_ACCENT?: string;
   readonly VITE_HOME_LINK?: string;
   readonly VITE_HOME_LINK_LABEL?: string;
 }


### PR DESCRIPTION
Follow-up to #134 addressing visual feedback ("staveniště" feel) on the staging deployment. This PR collects 8 overnight visual-iteration commits into a single squashable change, so `main` keeps a clean, PR-based history.

## Why a separate PR

#134 shipped the configurable branding + homepage hero, but the resulting design felt like "a construction site" on the live deploy. We iterated 8 times directly against staging (push → Railway deploy → Playwright screenshot → adjust → repeat) using real data on the staging URL. Squashing those iterations through a proper PR keeps `main` history matching the project's standard squash-merge workflow.

## What changed since #134

**Hero**
- Switch from `section="generic"` (whose pale `--color-primary-*` gradient produced near-invisible white-on-pale title) to `section="dv"` (whitewater blue) — gives the hardcoded dark gradient that the white DS title was designed for. Semantically correct for canoe slalom too.
- Add `meshBackground` + `patternOverlay` + `csk-reveal-1` entrance animation.
- Drop `wave` divider for a cleaner straight transition.
- Add `LIVE • {n}` energy badge above the fold when running races exist.
- New `VITE_APP_SUBTITLE_ACCENT` env var (default `kanoistického slalomu`) controls which substring of the subtitle gets the light-blue accent color via DS `titleAccent` prop. Falls back gracefully when the substring isn't present.

**Status grouping & headings**
- Group events into running / upcoming / finished sections via `useMemo`, render in that order.
- Custom `SectionHeading` component (replaces `SectionHeader` from DS, which was visually too quiet to feel like a heading): bolder typography, coral 4px left-border accent on the live section, inline pulsing live dot, smaller muted description with Czech-pluralized race count ("1 závod běží právě teď", "3 závody...", "12 závodů...").
- **Headings are hidden when only one status group is non-empty** — with a single live race the hero LIVE badge plus the per-card status badge already convey context, so the heading would just add noise. Headings re-appear when 2+ groups have content.

**Cards**
- Live cards use `Card variant="aesthetic"` from the DS — gradient (blue → orange) 4px left border + subtle mesh background + hover lift + glow. Communicates "this is a live race" visually instead of relying on text alone.
- Non-live cards use `variant="elevated"`.
- Card title scales up to 1.25rem when emphasised.
- Location and date now render with `Icon name="map-pin"` + `Icon name="calendar"` from the DS Icon component (replaces plain text).
- Trailing `Icon name="chevron-right"` hints at interactivity.
- Status badge for running races now uses `variant="energy"` + `glow`.
- `<LiveIndicator />` now passes `variant="live"` + `energyGlow` + `pulse` so the dot actually animates (was rendering as a static gray dot before — the missing prop was the bug flagged as a side note in #134).
- Date format: `Intl.DateTimeFormat('cs-CZ', { day: 'numeric', month: 'long', year: 'numeric' })` produces `11. dubna – 13. dubna 2026` for date ranges.

**Layout**
- `PageLayout maxWidth="md"` (768px) instead of the default `xl` (1280px) — content doesn't stretch full-width on desktop.
- Wrapper with `csk-mesh-bg--subtle` class — barely-there blue + orange radial gradient under the hero so the white content area transitions softly from the dv-themed hero, instead of an abrupt blue → flat-white edge.
- `paddingInline: 1rem` on the wrapper so cards have visible inset from the viewport edges on mobile (previously flush against the PageLayout's 16px container padding).
- Tighter rhythm: `paddingBlock: 2rem` + `gap: 2.25rem`.

**Tests**
- `App.test.tsx` mock data now contains both a running and an upcoming event so the heading-rendering branch is exercised.
- Title query uses regex matchers because `titleAccent` splits the string across multiple span elements.
- Asserts `getAllByText('ČSK Live').length === 1` (header only — hero shows the subtitle, not the brand name).

## Files

| File | Change |
|---|---|
| `packages/client/src/pages/EventListPage.tsx` | HeroSection wiring, status grouping, custom SectionHeading, conditional heading render |
| `packages/client/src/components/EventList.tsx` | Aesthetic card variant, Icon usage, LiveIndicator variant=live, formatEventDate |
| `packages/client/src/config/branding.ts` | New `appSubtitleAccent` field; switch `??` → `\|\|` for empty-string fallback |
| `packages/client/src/vite-env.d.ts` | New `VITE_APP_SUBTITLE_ACCENT` ambient declaration |
| `packages/client/.env.example` | Document the new env var + substring constraint |
| `packages/client/src/App.test.tsx` | Multi-event mock, regex matchers, header-only `ČSK Live` assertion |
| `docs/RUNBOOK.md` | Document `VITE_APP_SUBTITLE_ACCENT` in the build-time branding table |

## History note

This PR replaces 8 direct-push commits to main (`eea985d..c66d1dc`) that were made during overnight iteration. After squash-merging this PR, main history goes from #134 directly to a single follow-up commit. Backup of the pre-cleanup state was kept locally; no production-tracked branches were affected.

## Test plan

- [x] `npx tsc --noEmit -p packages/client/tsconfig.json` clean
- [x] `npx vitest run` — 169 passed (16 files)
- [x] `npm run build` clean, default build verified to bake all four `VITE_*` defaults into the bundle
- [x] Custom `VITE_APP_NAME="Test Liga"` build verified to override defaults in the bundle
- [x] Mobile Playwright screenshot (375×812) — hero + card + footer fits, card has inset, no cramped headings
- [x] Tablet Playwright screenshot (768×1024) — hero contained at md width, card width matches
- [x] Desktop Playwright screenshot (1280×800) — same centered tile layout as tablet
- [x] Staging URL https://c123-live-mini-staging.up.railway.app/ live with all four `VITE_*` vars set
- [x] Production Railway env vars also set (defaults — user will edit values when ready to promote)

Refs #120 (already closed by #134; this is a follow-up polish).