### PR TITLE
release: promote main → production (#120 polish + branding accent)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -245,8 +245,9 @@ These variables are read by Vite **during the Nixpacks build phase** (`vite buil
 
 | Variable | Default | What it controls |
 |---|---|---|
-| `VITE_APP_NAME` | `ČSK Live` | Header title (satellite breadcrumb) **and** homepage hero title |
-| `VITE_APP_SUBTITLE` | `Živé výsledky kanoistického slalomu` | Homepage hero subtitle |
+| `VITE_APP_NAME` | `ČSK Live` | Header title (satellite breadcrumb) |
+| `VITE_APP_SUBTITLE` | `Živé výsledky kanoistického slalomu` | Homepage hero title |
+| `VITE_APP_SUBTITLE_ACCENT` | `kanoistického slalomu` | Substring of the subtitle rendered in the hero accent colour (light blue on the dv section). Must literally appear inside `VITE_APP_SUBTITLE`; otherwise the hero shows the full title in one colour. Set to a non-substring value to effectively disable the accent. |
 | `VITE_HOME_LINK` | `https://kanoe.cz` | Satellite header back-link URL |
 | `VITE_HOME_LINK_LABEL` | `Zpět na kanoe.cz` | Satellite header back-link text |
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -239,6 +239,25 @@ Both staging and production share the same set; values differ only for `MASTER_P
 
 Note: `NIXPACKS_NODE_VERSION` and `NPM_CONFIG_INCLUDE` were tried during the Railway debugging session and **removed** in the final working state — the vite override fix made them unnecessary. See DEVLOG 2026-04-10.
 
+### Build-time client branding (`VITE_*`)
+
+These variables are read by Vite **during the Nixpacks build phase** (`vite build` step) and baked into the JS bundle. Changing a value requires a **redeploy** for the SPA to pick it up — they are NOT runtime config. All have safe defaults baked into the source so unsetting them reproduces the original ČSK Live deployment exactly.
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `VITE_APP_NAME` | `ČSK Live` | Header title (satellite breadcrumb) **and** homepage hero title |
+| `VITE_APP_SUBTITLE` | `Živé výsledky kanoistického slalomu` | Homepage hero subtitle |
+| `VITE_HOME_LINK` | `https://kanoe.cz` | Satellite header back-link URL |
+| `VITE_HOME_LINK_LABEL` | `Zpět na kanoe.cz` | Satellite header back-link text |
+
+To change branding for an environment:
+
+1. Edit the variable in Railway dashboard (Project → service → Variables → select environment).
+2. Trigger a redeploy (`railway redeploy --service c123-live-mini --environment <env>` or push an empty commit; see "Forcing a redeploy" above).
+3. Verify the new value at the public URL.
+
+Local-dev override: copy `packages/client/.env.example` → `packages/client/.env.local` and edit, or pass inline like `VITE_APP_NAME="Foo" npx vite`.
+
 ---
 
 ## First-time bootstrap (after a fresh Railway deploy or DB reset)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -11,9 +11,11 @@ For deep architecture see [ARCHITECTURE.md](ARCHITECTURE.md). For historical deb
 | Environment | Branch watched | URL | Railway env name | Status |
 |---|---|---|---|---|
 | **staging** | `main` | https://c123-live-mini-staging.up.railway.app | `staging` | ✅ live |
-| **production** | `production` | *(not yet created)* | `production` | ⏸ deferred, see issue [#117](https://github.com/OpenCanoeTiming/c123-live-mini/issues/117) |
+| **production** | `production` | https://c123-live-mini.up.railway.app | `production` | ✅ live |
 
-**Auto-deploy flow:** push to `main` → GitHub Actions CI runs `npm ci && npm run build && npm test` → on green, Railway auto-deploys staging. Railway has **Wait for CI = ON**, so a failed CI check blocks the deploy.
+**Auto-deploy flow:** push to `main` → GitHub Actions CI runs `npm ci && npm run build && npm test` → on green, Railway auto-deploys staging. **Production** deploys from the `production` branch — push to `main` does **not** affect production. Promote to production by opening a release PR `main → production` and merging it; Railway then picks up the new commit on `production` and auto-deploys.
+
+Railway has **Wait for CI = ON** on both environments, so a failed CI check blocks the deploy.
 
 **Serverless sleep:** enabled. After ~10 min of no traffic, the container sleeps. First request after sleep has cold-start latency ~5–10 s (Nixpacks wake + Node boot + SQLite open). During a live race this is a non-issue because traffic is continuous.
 
@@ -200,31 +202,38 @@ curl -sS -X POST https://backboard.railway.com/graphql/v2 \
 
 ---
 
-## Railway IDs (staging)
+## Railway IDs
 
 Useful for scripting — these are not secret:
 
 | What | Value |
 |---|---|
-| Project | `skvs-live-mini` |
+| Project name | `skvs-live-mini` |
 | Project ID | `97408870-7b9e-4aa5-b3b1-5b546e4d1f34` |
-| Environment name | `staging` |
-| Environment ID | `b1c8ea80-c260-4819-bc9e-54de1a27fd62` |
 | Service name | `c123-live-mini` |
 | Service ID | `aadf519a-48b5-4da9-9259-21b9178a2619` |
-| Volume mount | `/data` |
-| Public domain | `c123-live-mini-staging.up.railway.app` |
+
+| Env | Env ID | Branch | Volume mount | Public domain |
+|---|---|---|---|---|
+| `staging` | `b1c8ea80-c260-4819-bc9e-54de1a27fd62` | `main` | `/data` | `c123-live-mini-staging.up.railway.app` |
+| `production` | `67189b9a-82ce-435f-931b-525053f50e36` | `production` | `/data` | `c123-live-mini.up.railway.app` |
+
+Both environments have **separate `MASTER_PASSWORDS`** and **separate `/data` volumes** (verified — staging volume `c123-live-mini-volume`, production volume `c123-live-mini-volume-prod`, no shared volume instances).
+
+Project tokens: each environment has its own scoped Project Access Token, both stored in `~/.config/c123-live-mini/railway.env` as `RAILWAY_TOKEN` (staging) and `RAILWAY_PROD_TOKEN` (production). To target production with a GraphQL call, replace the staging token in the `Project-Access-Token` header with the production one and the staging env ID with `RAILWAY_PROD_ENV_ID`.
 
 ---
 
-## Environment variables currently set on Railway staging
+## Environment variables currently set on Railway
+
+Both staging and production share the same set; values differ only for `MASTER_PASSWORDS`.
 
 | Variable | Purpose | Source |
 |---|---|---|
 | `NODE_ENV=production` | Activates SPA serving + admin safety check | Manual |
 | `DATABASE_PATH=/data/live-mini.db` | SQLite on mounted volume | Manual |
-| `MASTER_PASSWORDS=<strong-password>` | Admin API auth, required in prod | Manual (generated with `openssl rand -base64 24`) |
-| `NODE_AUTH_TOKEN=<GH PAT>` | Build-phase GitHub Packages auth for `@czechcanoe/rvp-design-system` | Manual |
+| `MASTER_PASSWORDS=<strong-password>` | Admin API auth, required in prod. **Different value per environment.** | Manual (generated with `openssl rand -base64 24`) |
+| `NODE_AUTH_TOKEN=<GH PAT>` | Build-phase GitHub Packages auth for `@czechcanoe/rvp-design-system`. Same value across environments. | Manual |
 | `LOG_LEVEL=info` | Fastify logger level | Manual |
 | `RAILWAY_*` | Service metadata (private domain, volume mount, etc.) | Railway-injected, read-only |
 

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,0 +1,17 @@
+# c123-live-mini client — branding configuration
+#
+# All variables below are OPTIONAL. The values shown here are the built-in
+# defaults baked into the source — leaving them unset reproduces the original
+# ČSK Live deployment exactly.
+#
+# Vite reads `VITE_*` variables at BUILD TIME (`npm run build` / `vite build`),
+# so changing them on Railway requires a redeploy to take effect. See
+# `docs/RUNBOOK.md` → "Build-time client branding" for the operational notes.
+#
+# Local dev: copy this file to `.env.local` and edit, OR pass inline:
+#   VITE_APP_NAME="Ligový pohár" npx vite
+
+VITE_APP_NAME="ČSK Live"
+VITE_APP_SUBTITLE="Živé výsledky kanoistického slalomu"
+VITE_HOME_LINK="https://kanoe.cz"
+VITE_HOME_LINK_LABEL="Zpět na kanoe.cz"

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -13,5 +13,10 @@
 
 VITE_APP_NAME="ČSK Live"
 VITE_APP_SUBTITLE="Živé výsledky kanoistického slalomu"
+# Optional: substring of VITE_APP_SUBTITLE rendered in the hero accent
+# colour (light blue on the dv section). Must literally appear inside
+# VITE_APP_SUBTITLE — otherwise the hero shows the whole title in one
+# colour. Leave commented out to disable the accent.
+VITE_APP_SUBTITLE_ACCENT="kanoistického slalomu"
 VITE_HOME_LINK="https://kanoe.cz"
 VITE_HOME_LINK_LABEL="Zpět na kanoe.cz"

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -5,7 +5,8 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import App from './App';
 
-// Mock data — updated for Feature #6 types (no id, no disId, uses raceType)
+// Mock data — two events in different status groups so the homepage
+// renders multiple sections (and therefore the section headings).
 const mockEvents = [
   {
     eventId: 'demo-2026',
@@ -16,6 +17,17 @@ const mockEvents = [
     endDate: '2026-02-06',
     discipline: null,
     status: 'running',
+    imageUrl: null,
+  },
+  {
+    eventId: 'demo-upcoming',
+    mainTitle: 'Upcoming Event',
+    subTitle: null,
+    location: 'Brno',
+    startDate: '2026-05-01',
+    endDate: '2026-05-03',
+    discipline: null,
+    status: 'startlist',
     imageUrl: null,
   },
 ];
@@ -55,9 +67,11 @@ describe('App', () => {
 
   it('renders the tagline as the homepage hero title', () => {
     render(<App />);
-    expect(
-      screen.getByText('Živé výsledky kanoistického slalomu')
-    ).toBeTruthy();
+    // The hero uses `titleAccent` which splits the title into multiple
+    // elements (a leading span + an accent span), so we can't match the
+    // whole string with a string-based query.
+    expect(screen.getByText(/Živé výsledky/)).toBeTruthy();
+    expect(screen.getByText(/kanoistického slalomu/)).toBeTruthy();
   });
 
   it('shows shared package version in footer', () => {

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -16,6 +16,7 @@ const mockEvents = [
     endDate: '2026-02-06',
     discipline: null,
     status: 'running',
+    imageUrl: null,
   },
 ];
 
@@ -45,9 +46,18 @@ afterEach(() => {
 });
 
 describe('App', () => {
-  it('renders the app title in header', () => {
+  it('renders the app name only in the satellite header (not duplicated in hero)', () => {
     render(<App />);
-    expect(screen.getByText('ČSK Live')).toBeTruthy();
+    // Hero promotes the subtitle/tagline to title to avoid duplicating
+    // appName above the fold — see EventListPage.tsx.
+    expect(screen.getAllByText('ČSK Live').length).toBe(1);
+  });
+
+  it('renders the tagline as the homepage hero title', () => {
+    render(<App />);
+    expect(
+      screen.getByText('Živé výsledky kanoistického slalomu')
+    ).toBeTruthy();
   });
 
   it('shows shared package version in footer', () => {
@@ -88,11 +98,11 @@ describe('App', () => {
     expect(container.querySelector('.csk-skeleton-card')).toBeTruthy();
   });
 
-  it('shows Czech section header', async () => {
+  it('groups running events under "Probíhá živě" status section', async () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText('Závody')).toBeTruthy();
+      expect(screen.getByText('Probíhá živě')).toBeTruthy();
     });
   });
 });

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -31,7 +31,12 @@ function App() {
 
   return (
     <Router hook={useHashLocation}>
-      <PageLayout variant="satellite" header={headerContent} footer={footerContent}>
+      <PageLayout
+        variant="satellite"
+        maxWidth="md"
+        header={headerContent}
+        footer={footerContent}
+      >
         <Switch>
           <Route path="/">
             <EventListPage />

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,10 +4,16 @@ import { Route, Switch, Router } from 'wouter';
 import { useHashLocation } from 'wouter/use-hash-location';
 import { EventListPage } from './pages/EventListPage';
 import { EventDetailPage } from './pages/EventDetailPage';
+import { branding } from './config/branding';
 
 function App() {
   const headerContent = (
-    <Header variant="satellite" appName="ČSK Live" />
+    <Header
+      variant="satellite"
+      appName={branding.appName}
+      homeLink={branding.homeLink}
+      homeLinkLabel={branding.homeLinkLabel}
+    />
   );
 
   const footerContent = (

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -1,18 +1,29 @@
-import { Card, Badge, EmptyState, LiveIndicator } from '@czechcanoe/rvp-design-system';
+import {
+  Card,
+  Badge,
+  EmptyState,
+  LiveIndicator,
+  Icon,
+} from '@czechcanoe/rvp-design-system';
 import type { PublicEventStatus } from '@c123-live-mini/shared';
 import type { EventListItem } from '../services/api';
 
 interface EventListProps {
   events: EventListItem[];
   onSelectEvent: (eventId: string) => void;
+  /**
+   * Highlight cards in this list as live/important
+   * (adds energy glow + elevated card variant).
+   */
+  emphasised?: boolean;
 }
 
 function getStatusVariant(
   status: PublicEventStatus
-): 'success' | 'default' | 'info' {
+): 'success' | 'default' | 'info' | 'energy' {
   switch (status) {
     case 'running':
-      return 'success';
+      return 'energy';
     case 'finished':
     case 'official':
       return 'info';
@@ -71,7 +82,11 @@ function formatEventDate(
   return `${dayMonthFormatter.format(start)} – ${dateFormatter.format(end)}`;
 }
 
-export function EventList({ events, onSelectEvent }: EventListProps) {
+export function EventList({
+  events,
+  onSelectEvent,
+  emphasised = false,
+}: EventListProps) {
   if (events.length === 0) {
     return (
       <Card>
@@ -87,9 +102,12 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
       {events.map((event) => {
         const dateLabel = formatEventDate(event.startDate, event.endDate);
+        const isRunning = event.status === 'running';
         return (
           <Card
             key={event.eventId}
+            variant={emphasised ? 'aesthetic' : 'elevated'}
+            padding="md"
             clickable
             onClick={() => onSelectEvent(event.eventId)}
           >
@@ -97,33 +115,33 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
               style={{
                 display: 'flex',
                 gap: '1rem',
-                alignItems: 'flex-start',
+                alignItems: 'center',
               }}
             >
               {event.imageUrl && (
                 <img
                   src={event.imageUrl}
                   alt=""
-                  width={64}
-                  height={64}
+                  width={72}
+                  height={72}
                   loading="lazy"
                   decoding="async"
                   style={{
-                    width: '64px',
-                    height: '64px',
+                    width: '72px',
+                    height: '72px',
                     flexShrink: 0,
                     objectFit: 'cover',
-                    borderRadius: 'var(--csk-radius-md, 8px)',
+                    borderRadius: 'var(--csk-radius-md, 12px)',
                   }}
                 />
               )}
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div
                   style={{
-                    fontSize: '1.125rem',
+                    fontSize: emphasised ? '1.25rem' : '1.125rem',
                     fontWeight: 700,
-                    lineHeight: 1.3,
-                    marginBottom: '0.25rem',
+                    lineHeight: 1.25,
+                    marginBottom: '0.375rem',
                   }}
                 >
                   {event.mainTitle}
@@ -133,7 +151,7 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                     style={{
                       fontSize: '0.875rem',
                       color: 'var(--csk-color-text-secondary)',
-                      marginBottom: '0.25rem',
+                      marginBottom: '0.375rem',
                     }}
                   >
                     {event.subTitle}
@@ -143,13 +161,35 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                   style={{
                     display: 'flex',
                     flexWrap: 'wrap',
-                    gap: '0.25rem 1rem',
+                    gap: '0.375rem 1rem',
                     fontSize: '0.875rem',
                     color: 'var(--csk-color-text-tertiary)',
                   }}
                 >
-                  {event.location && <span>{event.location}</span>}
-                  {dateLabel && <span>{dateLabel}</span>}
+                  {event.location && (
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.375rem',
+                      }}
+                    >
+                      <Icon name="map-pin" size="sm" aria-label="Místo" />
+                      {event.location}
+                    </span>
+                  )}
+                  {dateLabel && (
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.375rem',
+                      }}
+                    >
+                      <Icon name="calendar" size="sm" aria-label="Datum" />
+                      {dateLabel}
+                    </span>
+                  )}
                 </div>
               </div>
               <div
@@ -160,10 +200,27 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
                   flexShrink: 0,
                 }}
               >
-                {event.status === 'running' && <LiveIndicator />}
-                <Badge variant={getStatusVariant(event.status)}>
+                {isRunning && (
+                  <LiveIndicator
+                    variant="live"
+                    size="sm"
+                    energyGlow
+                    pulse
+                  />
+                )}
+                <Badge
+                  variant={getStatusVariant(event.status)}
+                  size="md"
+                  glow={isRunning}
+                >
                   {getStatusLabel(event.status)}
                 </Badge>
+                <Icon
+                  name="chevron-right"
+                  size="md"
+                  aria-hidden
+                  className="csk-color-on-surface-muted"
+                />
               </div>
             </div>
           </Card>

--- a/packages/client/src/components/EventList.tsx
+++ b/packages/client/src/components/EventList.tsx
@@ -1,4 +1,5 @@
 import { Card, Badge, EmptyState, LiveIndicator } from '@czechcanoe/rvp-design-system';
+import type { PublicEventStatus } from '@c123-live-mini/shared';
 import type { EventListItem } from '../services/api';
 
 interface EventListProps {
@@ -6,44 +7,70 @@ interface EventListProps {
   onSelectEvent: (eventId: string) => void;
 }
 
-/**
- * Map event status to Badge variant
- */
-function getStatusVariant(status: string): 'success' | 'default' | 'info' {
+function getStatusVariant(
+  status: PublicEventStatus
+): 'success' | 'default' | 'info' {
   switch (status) {
     case 'running':
       return 'success';
     case 'finished':
     case 'official':
       return 'info';
-    default:
+    case 'startlist':
       return 'default';
   }
 }
 
-/**
- * Map event status to Czech label
- */
-function getStatusLabel(status: string): string {
+function getStatusLabel(status: PublicEventStatus): string {
   switch (status) {
     case 'running':
       return 'probíhá';
     case 'finished':
-      return 'dokončeno';
     case 'official':
       return 'dokončeno';
     case 'startlist':
       return 'startovní listina';
-    case 'draft':
-      return 'příprava';
-    default:
-      return status;
   }
 }
 
+const dateFormatter = new Intl.DateTimeFormat('cs-CZ', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+
+const dayMonthFormatter = new Intl.DateTimeFormat('cs-CZ', {
+  day: 'numeric',
+  month: 'long',
+});
+
 /**
- * Display a list of events using DS components
+ * Format an event date or date range in Czech locale.
+ *
+ * - single day → "5. května 2026"
+ * - range → "1. května – 3. května 2026"
+ * - returns null when both inputs are missing or unparseable
  */
+function formatEventDate(
+  startDate: string | null,
+  endDate: string | null
+): string | null {
+  if (!startDate) return null;
+  const start = new Date(startDate);
+  if (Number.isNaN(start.getTime())) return null;
+
+  if (!endDate || endDate === startDate) {
+    return dateFormatter.format(start);
+  }
+
+  const end = new Date(endDate);
+  if (Number.isNaN(end.getTime())) {
+    return dateFormatter.format(start);
+  }
+
+  return `${dayMonthFormatter.format(start)} – ${dateFormatter.format(end)}`;
+}
+
 export function EventList({ events, onSelectEvent }: EventListProps) {
   if (events.length === 0) {
     return (
@@ -57,57 +84,91 @@ export function EventList({ events, onSelectEvent }: EventListProps) {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-      {events.map((event) => (
-        <Card
-          key={event.eventId}
-          clickable
-          onClick={() => onSelectEvent(event.eventId)}
-        >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              gap: '0.5rem',
-            }}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      {events.map((event) => {
+        const dateLabel = formatEventDate(event.startDate, event.endDate);
+        return (
+          <Card
+            key={event.eventId}
+            clickable
+            onClick={() => onSelectEvent(event.eventId)}
           >
-            <div>
-              <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
-                {event.mainTitle}
-              </div>
-              {event.subTitle && (
+            <div
+              style={{
+                display: 'flex',
+                gap: '1rem',
+                alignItems: 'flex-start',
+              }}
+            >
+              {event.imageUrl && (
+                <img
+                  src={event.imageUrl}
+                  alt=""
+                  width={64}
+                  height={64}
+                  loading="lazy"
+                  decoding="async"
+                  style={{
+                    width: '64px',
+                    height: '64px',
+                    flexShrink: 0,
+                    objectFit: 'cover',
+                    borderRadius: 'var(--csk-radius-md, 8px)',
+                  }}
+                />
+              )}
+              <div style={{ flex: 1, minWidth: 0 }}>
                 <div
                   style={{
-                    fontSize: '0.875rem',
-                    color: 'var(--csk-color-text-secondary)',
+                    fontSize: '1.125rem',
+                    fontWeight: 700,
+                    lineHeight: 1.3,
                     marginBottom: '0.25rem',
                   }}
                 >
-                  {event.subTitle}
+                  {event.mainTitle}
                 </div>
-              )}
+                {event.subTitle && (
+                  <div
+                    style={{
+                      fontSize: '0.875rem',
+                      color: 'var(--csk-color-text-secondary)',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    {event.subTitle}
+                  </div>
+                )}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '0.25rem 1rem',
+                    fontSize: '0.875rem',
+                    color: 'var(--csk-color-text-tertiary)',
+                  }}
+                >
+                  {event.location && <span>{event.location}</span>}
+                  {dateLabel && <span>{dateLabel}</span>}
+                </div>
+              </div>
               <div
                 style={{
                   display: 'flex',
-                  gap: '1rem',
-                  fontSize: '0.875rem',
-                  color: 'var(--csk-color-text-tertiary)',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  flexShrink: 0,
                 }}
               >
-                {event.location && <span>{event.location}</span>}
-                {event.startDate && <span>{event.startDate}</span>}
+                {event.status === 'running' && <LiveIndicator />}
+                <Badge variant={getStatusVariant(event.status)}>
+                  {getStatusLabel(event.status)}
+                </Badge>
               </div>
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              {event.status === 'running' && <LiveIndicator />}
-              <Badge variant={getStatusVariant(event.status)}>
-                {getStatusLabel(event.status)}
-              </Badge>
-            </div>
-          </div>
-        </Card>
-      ))}
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/packages/client/src/config/branding.ts
+++ b/packages/client/src/config/branding.ts
@@ -11,6 +11,13 @@
 export interface Branding {
   appName: string;
   appSubtitle: string;
+  /**
+   * Optional substring of `appSubtitle` to render in the hero accent color
+   * (light blue per the `dv` section). Must literally appear inside
+   * `appSubtitle` — otherwise the hero just shows the full title in one
+   * colour. Leave unset to disable the accent.
+   */
+  appSubtitleAccent?: string;
   homeLink: string;
   homeLinkLabel: string;
 }
@@ -22,6 +29,8 @@ export const branding: Branding = {
   appName: import.meta.env.VITE_APP_NAME || 'ČSK Live',
   appSubtitle:
     import.meta.env.VITE_APP_SUBTITLE || 'Živé výsledky kanoistického slalomu',
+  appSubtitleAccent:
+    import.meta.env.VITE_APP_SUBTITLE_ACCENT || 'kanoistického slalomu',
   homeLink: import.meta.env.VITE_HOME_LINK || 'https://kanoe.cz',
   homeLinkLabel: import.meta.env.VITE_HOME_LINK_LABEL || 'Zpět na kanoe.cz',
 };

--- a/packages/client/src/config/branding.ts
+++ b/packages/client/src/config/branding.ts
@@ -1,0 +1,27 @@
+/**
+ * Branding configuration for the c123-live-mini client.
+ *
+ * Values come from build-time `VITE_*` env vars, with defaults that match
+ * the original ČSK Live deployment so unset variables cause no visible
+ * change. To rebrand a deployment, set the corresponding variables in the
+ * Railway project (build phase) and trigger a redeploy. See
+ * `packages/client/.env.example` and `docs/RUNBOOK.md` for the full list.
+ */
+
+export interface Branding {
+  appName: string;
+  appSubtitle: string;
+  homeLink: string;
+  homeLinkLabel: string;
+}
+
+// Use `||` (not `??`) so an empty-string value entered in the Railway UI
+// falls back to the default — clearing a variable without deleting it would
+// otherwise produce a blank header / hero with no warning.
+export const branding: Branding = {
+  appName: import.meta.env.VITE_APP_NAME || 'ČSK Live',
+  appSubtitle:
+    import.meta.env.VITE_APP_SUBTITLE || 'Živé výsledky kanoistického slalomu',
+  homeLink: import.meta.env.VITE_HOME_LINK || 'https://kanoe.cz',
+  homeLinkLabel: import.meta.env.VITE_HOME_LINK_LABEL || 'Zpět na kanoe.cz',
+};

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
+  HeroSection,
   SectionHeader,
   SkeletonCard,
   Card,
@@ -9,8 +10,40 @@ import {
 import { useLocation } from 'wouter';
 import { getEvents, ApiError, type EventListItem } from '../services/api';
 import { EventList } from '../components/EventList';
+import { branding } from '../config/branding';
 
 type LoadingState = 'idle' | 'loading' | 'success' | 'error';
+
+interface EventGroups {
+  running: EventListItem[];
+  upcoming: EventListItem[];
+  finished: EventListItem[];
+}
+
+const STATUS_SECTIONS: Array<{ key: keyof EventGroups; title: string }> = [
+  { key: 'running', title: 'Probíhá živě' },
+  { key: 'upcoming', title: 'Nadcházející' },
+  { key: 'finished', title: 'Skončené' },
+];
+
+function groupEventsByStatus(events: EventListItem[]): EventGroups {
+  const groups: EventGroups = { running: [], upcoming: [], finished: [] };
+  for (const event of events) {
+    switch (event.status) {
+      case 'running':
+        groups.running.push(event);
+        break;
+      case 'startlist':
+        groups.upcoming.push(event);
+        break;
+      case 'finished':
+      case 'official':
+        groups.finished.push(event);
+        break;
+    }
+  }
+  return groups;
+}
 
 export function EventListPage() {
   const [events, setEvents] = useState<EventListItem[]>([]);
@@ -46,9 +79,23 @@ export function EventListPage() {
     [navigate]
   );
 
+  const groups = useMemo(() => groupEventsByStatus(events), [events]);
+  const hasAnyEvents = events.length > 0;
+
   return (
-    <section>
-      <SectionHeader title="Závody" />
+    <>
+      {/*
+        The satellite Header already shows `branding.appName`. Use the
+        tagline as the hero title so we don't repeat the brand name above
+        the fold on mobile (review feedback on #134).
+      */}
+      <HeroSection
+        variant="minimal"
+        section="generic"
+        title={branding.appSubtitle}
+        meshBackground
+        wave
+      />
 
       {state === 'loading' && <SkeletonCard />}
 
@@ -57,19 +104,41 @@ export function EventListPage() {
           <EmptyState
             title="Chyba připojení"
             description={error ?? 'Nepodařilo se připojit k serveru'}
-            action={
-              <Button onClick={fetchEvents}>Zkusit znovu</Button>
-            }
+            action={<Button onClick={fetchEvents}>Zkusit znovu</Button>}
           />
         </Card>
       )}
 
-      {state === 'success' && (
-        <EventList
-          events={events}
-          onSelectEvent={handleSelectEvent}
-        />
+      {state === 'success' && !hasAnyEvents && (
+        <Card>
+          <EmptyState
+            title="Žádné závody nejsou k dispozici"
+            description="Momentálně nejsou vypsány žádné závody."
+          />
+        </Card>
       )}
-    </section>
+
+      {state === 'success' && hasAnyEvents && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1.5rem',
+          }}
+        >
+          {STATUS_SECTIONS.map(({ key, title }) =>
+            groups[key].length > 0 ? (
+              <section key={key}>
+                <SectionHeader title={title} />
+                <EventList
+                  events={groups[key]}
+                  onSelectEvent={handleSelectEvent}
+                />
+              </section>
+            ) : null
+          )}
+        </div>
+      )}
+    </>
   );
 }

--- a/packages/client/src/pages/EventListPage.tsx
+++ b/packages/client/src/pages/EventListPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   HeroSection,
-  SectionHeader,
   SkeletonCard,
   Card,
   EmptyState,
   Button,
+  Badge,
+  LiveIndicator,
 } from '@czechcanoe/rvp-design-system';
 import { useLocation } from 'wouter';
 import { getEvents, ApiError, type EventListItem } from '../services/api';
@@ -20,11 +21,30 @@ interface EventGroups {
   finished: EventListItem[];
 }
 
-const STATUS_SECTIONS: Array<{ key: keyof EventGroups; title: string }> = [
-  { key: 'running', title: 'Probíhá živě' },
+interface StatusSectionConfig {
+  key: keyof EventGroups;
+  title: string;
+  isLive?: boolean;
+}
+
+const STATUS_SECTIONS: StatusSectionConfig[] = [
+  { key: 'running', title: 'Probíhá živě', isLive: true },
   { key: 'upcoming', title: 'Nadcházející' },
   { key: 'finished', title: 'Skončené' },
 ];
+
+/** Czech pluralization for "závod" (race). */
+function raceCountLabel(count: number): string {
+  if (count === 1) return '1 závod';
+  if (count >= 2 && count <= 4) return `${count} závody`;
+  return `${count} závodů`;
+}
+
+const SECTION_DESCRIPTIONS: Record<keyof EventGroups, (n: number) => string> = {
+  running: (n) => `${raceCountLabel(n)} běží právě teď`,
+  upcoming: (n) => `${raceCountLabel(n)} v nejbližší době`,
+  finished: (n) => `${raceCountLabel(n)} už máme za sebou`,
+};
 
 function groupEventsByStatus(events: EventListItem[]): EventGroups {
   const groups: EventGroups = { running: [], upcoming: [], finished: [] };
@@ -43,6 +63,66 @@ function groupEventsByStatus(events: EventListItem[]): EventGroups {
     }
   }
   return groups;
+}
+
+interface SectionHeadingProps {
+  title: string;
+  description: string;
+  isLive?: boolean;
+}
+
+/**
+ * Custom section heading with stronger visual hierarchy than the
+ * design-system `SectionHeader` (which is intentionally subtle).
+ *
+ * Live sections get a coral accent bar, an inline pulsing live dot,
+ * and a slightly larger title — so spectators immediately spot the
+ * "Probíhá živě" block when they land on the page.
+ */
+function SectionHeading({ title, description, isLive }: SectionHeadingProps) {
+  return (
+    <header
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.25rem',
+        marginBottom: '0.875rem',
+        paddingLeft: isLive ? '0.875rem' : 0,
+        borderLeft: isLive
+          ? '4px solid var(--color-energy-500, #f97316)'
+          : undefined,
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.625rem',
+          fontSize: isLive ? '1.5rem' : '1.25rem',
+          fontWeight: 800,
+          letterSpacing: '-0.01em',
+          lineHeight: 1.2,
+          color: 'var(--csk-color-on-surface, var(--color-text-primary))',
+        }}
+      >
+        {title}
+        {isLive && (
+          <LiveIndicator variant="live" size="md" energyGlow pulse />
+        )}
+      </h2>
+      <p
+        style={{
+          margin: 0,
+          fontSize: '0.9375rem',
+          color:
+            'var(--csk-color-on-surface-muted, var(--color-text-secondary))',
+        }}
+      >
+        {description}
+      </p>
+    </header>
+  );
 }
 
 export function EventListPage() {
@@ -81,64 +161,89 @@ export function EventListPage() {
 
   const groups = useMemo(() => groupEventsByStatus(events), [events]);
   const hasAnyEvents = events.length > 0;
+  const liveCount = groups.running.length;
+  const visibleSectionCount = STATUS_SECTIONS.filter(
+    (s) => groups[s.key].length > 0
+  ).length;
+  // When only a single status group is non-empty, the section heading is
+  // redundant — the hero badge + the cards' own status badges already
+  // tell the user what they're looking at. Skip headings in that case.
+  const showHeadings = visibleSectionCount > 1;
 
   return (
     <>
-      {/*
-        The satellite Header already shows `branding.appName`. Use the
-        tagline as the hero title so we don't repeat the brand name above
-        the fold on mobile (review feedback on #134).
-      */}
       <HeroSection
-        variant="minimal"
-        section="generic"
+        variant="compact"
+        section="dv"
         title={branding.appSubtitle}
+        titleAccent={branding.appSubtitleAccent}
         meshBackground
-        wave
+        patternOverlay
+        badges={
+          liveCount > 0 ? (
+            <Badge variant="energy" size="lg" glow>
+              LIVE • {liveCount}
+            </Badge>
+          ) : undefined
+        }
+        className="csk-reveal csk-reveal-1"
       />
 
-      {state === 'loading' && <SkeletonCard />}
+      <div
+        className="csk-mesh-bg--subtle"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2.25rem',
+          paddingBlock: '2rem',
+          paddingInline: '1rem',
+        }}
+      >
+        {state === 'loading' && <SkeletonCard />}
 
-      {state === 'error' && (
-        <Card>
-          <EmptyState
-            title="Chyba připojení"
-            description={error ?? 'Nepodařilo se připojit k serveru'}
-            action={<Button onClick={fetchEvents}>Zkusit znovu</Button>}
-          />
-        </Card>
-      )}
+        {state === 'error' && (
+          <Card>
+            <EmptyState
+              title="Chyba připojení"
+              description={error ?? 'Nepodařilo se připojit k serveru'}
+              action={<Button onClick={fetchEvents}>Zkusit znovu</Button>}
+            />
+          </Card>
+        )}
 
-      {state === 'success' && !hasAnyEvents && (
-        <Card>
-          <EmptyState
-            title="Žádné závody nejsou k dispozici"
-            description="Momentálně nejsou vypsány žádné závody."
-          />
-        </Card>
-      )}
+        {state === 'success' && !hasAnyEvents && (
+          <Card>
+            <EmptyState
+              title="Žádné závody nejsou k dispozici"
+              description="Momentálně nejsou vypsány žádné závody."
+            />
+          </Card>
+        )}
 
-      {state === 'success' && hasAnyEvents && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '1.5rem',
-          }}
-        >
-          {STATUS_SECTIONS.map(({ key, title }) =>
+        {state === 'success' &&
+          hasAnyEvents &&
+          STATUS_SECTIONS.map(({ key, title, isLive }, idx) =>
             groups[key].length > 0 ? (
-              <section key={key}>
-                <SectionHeader title={title} />
+              <section
+                key={key}
+                className={`csk-reveal csk-reveal-${idx + 2}`}
+              >
+                {showHeadings && (
+                  <SectionHeading
+                    title={title}
+                    description={SECTION_DESCRIPTIONS[key](groups[key].length)}
+                    isLive={isLive}
+                  />
+                )}
                 <EventList
                   events={groups[key]}
                   onSelectEvent={handleSelectEvent}
+                  emphasised={isLive}
                 />
               </section>
             ) : null
           )}
-        </div>
-      )}
+      </div>
     </>
   );
 }

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_APP_NAME?: string;
   readonly VITE_APP_SUBTITLE?: string;
+  readonly VITE_APP_SUBTITLE_ACCENT?: string;
   readonly VITE_HOME_LINK?: string;
   readonly VITE_HOME_LINK_LABEL?: string;
 }

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME?: string;
+  readonly VITE_APP_SUBTITLE?: string;
+  readonly VITE_HOME_LINK?: string;
+  readonly VITE_HOME_LINK_LABEL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/railway.toml
+++ b/railway.toml
@@ -10,6 +10,13 @@
 #   @czechcanoe/rvp-design-system. Set as a Railway project variable,
 #   marked for the build phase. See .npmrc.example for details.
 #
+# Build-time client branding (optional, all have defaults — see
+# packages/client/.env.example and docs/RUNBOOK.md):
+#   VITE_APP_NAME           — header + hero title
+#   VITE_APP_SUBTITLE       — hero subtitle
+#   VITE_HOME_LINK          — satellite header back-link URL
+#   VITE_HOME_LINK_LABEL    — satellite header back-link text
+#
 # Runtime env vars (set per environment in Railway):
 #   NODE_ENV=production
 #   DATABASE_PATH=/data/live-mini.db   (must point to mounted volume)


### PR DESCRIPTION
Release PR promoting `main` → `production`. Picks up the visual polish and branding-accent work from #120 follow-ups.

## What's being promoted

Two PRs since the last release (#131):

- **#134** — `feat(client): configurable branding + homepage hero` — VITE_APP_NAME / VITE_APP_SUBTITLE / VITE_HOME_LINK / VITE_HOME_LINK_LABEL build-time env vars, HeroSection on homepage, status grouping (running / upcoming / finished), improved cards.
- **#135** — `feat(client): polish homepage visual quality (#120 follow-up)` — dv-themed hero, aesthetic Card variant for live races, custom SectionHeading with coral accent + Czech-pluralized count, mobile inset, conditional headings, new `VITE_APP_SUBTITLE_ACCENT` env var.

## Files

```
docs/RUNBOOK.md                              | 51 ++++--
packages/client/.env.example                 | 22 +++
packages/client/src/App.test.tsx             | 34 +++-
packages/client/src/App.tsx                  | 15 +-
packages/client/src/components/EventList.tsx | 228 +++++++++++++++++++-------
packages/client/src/config/branding.ts       | 36 +++++
packages/client/src/pages/EventListPage.tsx  | 226 +++++++++++++++++++++++---
packages/client/src/vite-env.d.ts            | 13 ++
railway.toml                                 | 7 +
9 files changed, 533 insertions(+), 99 deletions(-)
```

Server code is **unchanged** — both PRs are client-only.

## Production env vars

Production already has these `VITE_*` variables set (from #134 follow-up):

- `VITE_APP_NAME` (default: `ČSK Live`)
- `VITE_APP_SUBTITLE` (default: `Živé výsledky kanoistického slalomu`)
- `VITE_HOME_LINK` (default: `https://kanoe.cz`)
- `VITE_HOME_LINK_LABEL` (default: `Zpět na kanoe.cz`)

After this PR merges, production will pick up the **new** `VITE_APP_SUBTITLE_ACCENT` variable too (already set on production with the default `kanoistického slalomu` to preserve the two-tone hero look). Edit any of them in the Railway production environment to rebrand without a code change.

## Test plan

- [x] Staging (https://c123-live-mini-staging.up.railway.app/) has been running this exact code (`e419770`) for the past hour with custom SK Vodní slalom ČB branding via env vars — visually verified at mobile/tablet/desktop with Playwright. No regressions.
- [x] CI green on main (run that produced `e419770`)
- [ ] CI green on this release PR
- [ ] Production Railway deploy SUCCESS after merge
- [ ] Smoke test https://c123-live-mini.up.railway.app/ — `/health` 200, SPA shell 200 with the new build, `/api/v1/events` works