### PR TITLE
feat(client): show both run start times in BR startlist

### DIFF
--- a/packages/client/src/components/StartlistTable.test.tsx
+++ b/packages/client/src/components/StartlistTable.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { StartlistTable } from './StartlistTable';
+import type { StartlistDisplayRow } from '../services/api';
+
+function row(overrides: Partial<StartlistDisplayRow> & { name: string }): StartlistDisplayRow {
+  return {
+    startOrder: overrides.startOrder ?? null,
+    bib: overrides.bib ?? null,
+    athleteId: overrides.athleteId ?? null,
+    name: overrides.name,
+    club: overrides.club ?? null,
+    noc: overrides.noc ?? null,
+    catId: overrides.catId ?? null,
+    startTime: overrides.startTime ?? null,
+    ...(overrides.run1StartTime !== undefined ? { run1StartTime: overrides.run1StartTime } : {}),
+    ...(overrides.run2StartTime !== undefined ? { run2StartTime: overrides.run2StartTime } : {}),
+  };
+}
+
+describe('StartlistTable', () => {
+  afterEach(() => cleanup());
+
+  it('renders single "Start" column for non-BR rows', () => {
+    render(
+      <StartlistTable
+        entries={[
+          row({ name: 'Novak J.', startTime: '2026-04-11T09:00:00', startOrder: 1, bib: 1 }),
+        ]}
+      />
+    );
+    expect(screen.getByText('Start')).toBeTruthy();
+    expect(screen.queryByText('B1')).toBeNull();
+    expect(screen.queryByText('B2')).toBeNull();
+  });
+
+  it('renders B1 / B2 columns when rows include both run times', () => {
+    render(
+      <StartlistTable
+        entries={[
+          row({
+            name: 'Novak J.',
+            startOrder: 1,
+            bib: 1,
+            startTime: '2026-04-11T10:00:00',
+            run1StartTime: '2026-04-11T08:00:00',
+            run2StartTime: '2026-04-11T10:00:00',
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText('B1')).toBeTruthy();
+    expect(screen.getByText('B2')).toBeTruthy();
+    expect(screen.queryByText('Start')).toBeNull();
+    // Both formatted times present (HH:MM)
+    expect(screen.getByText('08:00')).toBeTruthy();
+    expect(screen.getByText('10:00')).toBeTruthy();
+  });
+
+  it('renders dash for missing run start time (BR1-only entry)', () => {
+    render(
+      <StartlistTable
+        entries={[
+          row({
+            name: 'Withdraw W.',
+            startOrder: 2,
+            bib: 99,
+            startTime: '2026-04-11T08:01:00',
+            run1StartTime: '2026-04-11T08:01:00',
+            run2StartTime: null,
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText('08:01')).toBeTruthy();
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+});

--- a/packages/client/src/components/StartlistTable.tsx
+++ b/packages/client/src/components/StartlistTable.tsx
@@ -3,18 +3,21 @@ import {
   EmptyState,
   type ColumnDef,
 } from '@czechcanoe/rvp-design-system';
-import type { StartlistEntry } from '../services/api';
+import type { StartlistDisplayRow } from '../services/api';
 import styles from './StartlistTable.module.css';
 
-function formatStartTime(isoString: string | null): string {
-  if (!isoString) return '';
+function formatStartTime(isoString: string | null | undefined): string {
+  if (!isoString) return '—';
   const date = new Date(isoString);
   if (isNaN(date.getTime())) return isoString;
   return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
 }
 
-function buildColumns(hasStartTimes: boolean): ColumnDef<StartlistEntry>[] {
-  const cols: ColumnDef<StartlistEntry>[] = [
+function buildColumns(
+  hasStartTimes: boolean,
+  hasBothRuns: boolean
+): ColumnDef<StartlistDisplayRow>[] {
+  const cols: ColumnDef<StartlistDisplayRow>[] = [
     {
       key: 'startOrder',
       header: 'Pořadí',
@@ -31,7 +34,32 @@ function buildColumns(hasStartTimes: boolean): ColumnDef<StartlistEntry>[] {
     },
   ];
 
-  if (hasStartTimes) {
+  if (hasBothRuns) {
+    cols.push(
+      {
+        key: 'run1StartTime',
+        header: 'B1',
+        width: '55px',
+        align: 'center',
+        cell: (row) => (
+          <span className={styles.startTime}>
+            {formatStartTime(row.run1StartTime)}
+          </span>
+        ),
+      },
+      {
+        key: 'run2StartTime',
+        header: 'B2',
+        width: '55px',
+        align: 'center',
+        cell: (row) => (
+          <span className={styles.startTime}>
+            {formatStartTime(row.run2StartTime)}
+          </span>
+        ),
+      }
+    );
+  } else if (hasStartTimes) {
     cols.push({
       key: 'startTime',
       header: 'Start',
@@ -72,7 +100,7 @@ function buildColumns(hasStartTimes: boolean): ColumnDef<StartlistEntry>[] {
 }
 
 interface StartlistTableProps {
-  entries: StartlistEntry[];
+  entries: StartlistDisplayRow[];
 }
 
 export function StartlistTable({ entries }: StartlistTableProps) {
@@ -85,11 +113,14 @@ export function StartlistTable({ entries }: StartlistTableProps) {
     );
   }
 
+  const hasBothRuns = entries.some(
+    (e) => e.run1StartTime !== undefined || e.run2StartTime !== undefined
+  );
   const hasStartTimes = entries.some((e) => e.startTime != null);
-  const columns = buildColumns(hasStartTimes);
+  const columns = buildColumns(hasStartTimes, hasBothRuns);
   const entriesWithKey = entries.map((e, i) => ({
     ...e,
-    _rowKey: `${e.athleteId ?? 'x'}-${e.catId ?? 'x'}-${e.startOrder ?? i}`,
+    _rowKey: `${e.athleteId ?? 'x'}-${e.catId ?? 'x'}-${e.startOrder ?? i}-${i}`,
   }));
 
   return (

--- a/packages/client/src/pages/EventDetailPage.tsx
+++ b/packages/client/src/pages/EventDetailPage.tsx
@@ -14,13 +14,13 @@ import {
   getEventDetails,
   getEventResults,
   getCategories,
-  getStartlist,
+  getStartlistMaybeBr,
   ApiError,
   type EventDetail,
   type RaceInfo,
   type ResultsResponse,
   type CategoryInfo,
-  type StartlistEntry,
+  type StartlistDisplayRow,
 } from '../services/api';
 import { groupRaces, extractDays, getDisplayRaces, type ClassGroup, type DayInfo } from '../utils/groupRaces';
 import { isBestRunRace } from '../utils/raceTypeLabels';
@@ -74,7 +74,7 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
   const [viewMode, setViewMode] = useState<ViewMode>('simple');
 
   // Results/startlist state
-  const [startlist, setStartlist] = useState<StartlistEntry[] | null>(null);
+  const [startlist, setStartlist] = useState<StartlistDisplayRow[] | null>(null);
   const [resultsState, setResultsState] = useState<LoadingState>('idle');
   const [currentRaceInfo, setCurrentRaceInfo] = useState<ResultsResponse['race'] | null>(null);
 
@@ -420,7 +420,7 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
           getEventResults(eventId, raceId, {
             catId: selectedCatId ?? undefined,
           }),
-          getStartlist(eventId, raceId).catch(() => [] as StartlistEntry[]),
+          getStartlistMaybeBr(eventId, raceId).catch(() => [] as StartlistDisplayRow[]),
         ]);
 
         if (cancelled) return;
@@ -442,7 +442,7 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
       } catch {
         if (cancelled) return;
         try {
-          const startlistData = await getStartlist(eventId, raceId);
+          const startlistData = await getStartlistMaybeBr(eventId, raceId);
           if (cancelled) return;
           setStartlist(startlistData);
           setDataView('startlist');

--- a/packages/client/src/services/api.test.ts
+++ b/packages/client/src/services/api.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getStartlistMaybeBr } from './api';
+import type { StartlistEntry } from './api';
+
+/**
+ * Helper to build a minimal startlist entry.
+ */
+function entry(overrides: Partial<StartlistEntry> & { name: string }): StartlistEntry {
+  return {
+    startOrder: overrides.startOrder ?? null,
+    bib: overrides.bib ?? null,
+    athleteId: overrides.athleteId ?? null,
+    name: overrides.name,
+    club: overrides.club ?? null,
+    noc: overrides.noc ?? null,
+    catId: overrides.catId ?? null,
+    startTime: overrides.startTime ?? null,
+  };
+}
+
+/**
+ * Mock global fetch with a per-URL response map.
+ */
+function mockFetch(responses: Record<string, unknown>) {
+  return vi.fn(async (url: string) => {
+    const path = url.replace(/^\/api\/v1/, '');
+    if (path in responses) {
+      return new Response(JSON.stringify(responses[path]), { status: 200 });
+    }
+    return new Response(JSON.stringify({ error: 'NotFound', message: 'not found' }), {
+      status: 404,
+      statusText: 'Not Found',
+    });
+  });
+}
+
+describe('getStartlistMaybeBr', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns plain startlist for non-BR race (no run1/run2 fields)', async () => {
+    const startlist = [
+      entry({ name: 'Novak J.', athleteId: '100', startTime: '2026-04-11T09:00:00' }),
+    ];
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/events/E1/startlist/K1M_Q': {
+          race: { raceId: 'K1M_Q', classId: 'K1M', raceType: 'qualification', raceStatus: 1 },
+          startlist,
+        },
+      })
+    );
+
+    const rows = await getStartlistMaybeBr('E1', 'K1M_Q');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Novak J.');
+    expect(rows[0].run1StartTime).toBeUndefined();
+    expect(rows[0].run2StartTime).toBeUndefined();
+  });
+
+  it('union-merges BR1 + BR2 by athleteId when both runs exist', async () => {
+    const br1 = [
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 1, startTime: '2026-04-11T08:00:00' }),
+      entry({ name: 'Svoboda P.', athleteId: '200', startOrder: 2, startTime: '2026-04-11T08:01:00' }),
+    ];
+    const br2 = [
+      // Reverse order in run 2 (typical canoe slalom)
+      entry({ name: 'Svoboda P.', athleteId: '200', startOrder: 1, startTime: '2026-04-11T10:00:00' }),
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 2, startTime: '2026-04-11T10:01:00' }),
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/events/E1/startlist/K1M_BR2_1': {
+          race: { raceId: 'K1M_BR2_1', classId: 'K1M', raceType: 'best-run-2', raceStatus: 1 },
+          startlist: br2,
+        },
+        '/events/E1/startlist/K1M_BR1_1': {
+          race: { raceId: 'K1M_BR1_1', classId: 'K1M', raceType: 'best-run-1', raceStatus: 1 },
+          startlist: br1,
+        },
+      })
+    );
+
+    const rows = await getStartlistMaybeBr('E1', 'K1M_BR2_1');
+
+    // Order follows BR2 (queried)
+    expect(rows.map((r) => r.name)).toEqual(['Svoboda P.', 'Novak J.']);
+
+    // Each row has both run start times
+    expect(rows[0].run1StartTime).toBe('2026-04-11T08:01:00');
+    expect(rows[0].run2StartTime).toBe('2026-04-11T10:00:00');
+    expect(rows[1].run1StartTime).toBe('2026-04-11T08:00:00');
+    expect(rows[1].run2StartTime).toBe('2026-04-11T10:01:00');
+  });
+
+  it('appends BR1-only entries (DNS in run 2) below BR2 rows', async () => {
+    const br1 = [
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 1, startTime: '2026-04-11T08:00:00' }),
+      entry({ name: 'Withdraw W.', athleteId: '999', startOrder: 2, startTime: '2026-04-11T08:01:00' }),
+    ];
+    const br2 = [
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 1, startTime: '2026-04-11T10:00:00' }),
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/events/E1/startlist/K1M_BR2_1': {
+          race: { raceId: 'K1M_BR2_1', classId: 'K1M', raceType: 'best-run-2', raceStatus: 1 },
+          startlist: br2,
+        },
+        '/events/E1/startlist/K1M_BR1_1': {
+          race: { raceId: 'K1M_BR1_1', classId: 'K1M', raceType: 'best-run-1', raceStatus: 1 },
+          startlist: br1,
+        },
+      })
+    );
+
+    const rows = await getStartlistMaybeBr('E1', 'K1M_BR2_1');
+
+    expect(rows).toHaveLength(2);
+    // BR2 row first
+    expect(rows[0].name).toBe('Novak J.');
+    expect(rows[0].run1StartTime).toBe('2026-04-11T08:00:00');
+    expect(rows[0].run2StartTime).toBe('2026-04-11T10:00:00');
+    // BR1-only row appended
+    expect(rows[1].name).toBe('Withdraw W.');
+    expect(rows[1].run1StartTime).toBe('2026-04-11T08:01:00');
+    expect(rows[1].run2StartTime).toBeNull();
+  });
+
+  it('falls back to (bib|catId|name) when athleteId is null', async () => {
+    const br1 = [
+      entry({ name: 'Local L.', athleteId: null, bib: 5, catId: 'K1M', startTime: '08:00' }),
+    ];
+    const br2 = [
+      entry({ name: 'Local L.', athleteId: null, bib: 5, catId: 'K1M', startTime: '10:00' }),
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/events/E1/startlist/K1M_BR2_1': {
+          race: { raceId: 'K1M_BR2_1', classId: 'K1M', raceType: 'best-run-2', raceStatus: 1 },
+          startlist: br2,
+        },
+        '/events/E1/startlist/K1M_BR1_1': {
+          race: { raceId: 'K1M_BR1_1', classId: 'K1M', raceType: 'best-run-1', raceStatus: 1 },
+          startlist: br1,
+        },
+      })
+    );
+
+    const rows = await getStartlistMaybeBr('E1', 'K1M_BR2_1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].run1StartTime).toBe('08:00');
+    expect(rows[0].run2StartTime).toBe('10:00');
+  });
+
+  it('fail-soft when paired race 404s — queried side still renders', async () => {
+    const br2 = [
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 1, startTime: '2026-04-11T10:00:00' }),
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/events/E1/startlist/K1M_BR2_1': {
+          race: { raceId: 'K1M_BR2_1', classId: 'K1M', raceType: 'best-run-2', raceStatus: 1 },
+          startlist: br2,
+        },
+        // K1M_BR1_1 intentionally absent → 404
+      })
+    );
+
+    const rows = await getStartlistMaybeBr('E1', 'K1M_BR2_1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].run1StartTime).toBeNull();
+    expect(rows[0].run2StartTime).toBe('2026-04-11T10:00:00');
+  });
+
+  it('symmetric: BR1 queried also yields both run times', async () => {
+    const br1 = [
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 1, startTime: '08:00' }),
+    ];
+    const br2 = [
+      entry({ name: 'Novak J.', athleteId: '100', startOrder: 1, startTime: '10:00' }),
+    ];
+
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '/events/E1/startlist/K1M_BR1_1': {
+          race: { raceId: 'K1M_BR1_1', classId: 'K1M', raceType: 'best-run-1', raceStatus: 1 },
+          startlist: br1,
+        },
+        '/events/E1/startlist/K1M_BR2_1': {
+          race: { raceId: 'K1M_BR2_1', classId: 'K1M', raceType: 'best-run-2', raceStatus: 1 },
+          startlist: br2,
+        },
+      })
+    );
+
+    const rows = await getStartlistMaybeBr('E1', 'K1M_BR1_1');
+    expect(rows[0].run1StartTime).toBe('08:00');
+    expect(rows[0].run2StartTime).toBe('10:00');
+  });
+
+  it('propagates error when primary (queried) race fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        // Both absent → primary 404
+      })
+    );
+
+    await expect(getStartlistMaybeBr('E1', 'K1M_BR2_1')).rejects.toThrow();
+  });
+});

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -16,6 +16,7 @@ import type {
   PublicStartlistEntry,
   PublicOnCourseEntry,
 } from '@c123-live-mini/shared';
+import { getPairedBrRaceId } from '../utils/groupRaces';
 
 const API_BASE = '/api/v1';
 
@@ -56,6 +57,22 @@ export type ClassInfo = PublicClass;
 export type RaceInfo = PublicRace;
 export type CategoryInfo = PublicAggregatedCategory;
 export type StartlistEntry = PublicStartlistEntry;
+
+/**
+ * Display row for startlist tables.
+ *
+ * For non-BR races, only `startTime` is set; `run1StartTime`/`run2StartTime`
+ * are absent and the table renders a single "Start" column.
+ *
+ * For BR (best-of-two-runs) races, both `run1StartTime` and `run2StartTime`
+ * are present (either may be `null` if a participant only appears in one run)
+ * and the table renders two columns "B1" / "B2". `startTime` retains the
+ * queried race's start time for backward compat.
+ */
+export interface StartlistDisplayRow extends StartlistEntry {
+  run1StartTime?: string | null;
+  run2StartTime?: string | null;
+}
 
 /**
  * Result entry - combines standard, multi-run, and detailed fields
@@ -177,6 +194,103 @@ export async function getStartlist(
     `/events/${eventId}/startlist/${raceId}`
   );
   return response.startlist;
+}
+
+/**
+ * Build a stable merge key for joining BR1 and BR2 startlist entries.
+ *
+ * Prefers `athleteId` (= ICFId from C123 XML, stable across re-ingests).
+ * Falls back to `bib|catId|name` for participants without an ICF ID
+ * (typical at local races).
+ */
+function startlistMergeKey(entry: StartlistEntry): string {
+  if (entry.athleteId) return `aid:${entry.athleteId}`;
+  return `fb:${entry.bib ?? '_'}|${entry.catId ?? '_'}|${entry.name}`;
+}
+
+/**
+ * Union-merge startlists for BR1 and BR2 of the same race.
+ *
+ * - `queried` rows come first, in their existing `start_order` (typically
+ *   BR2 in reverse-of-BR1 order — what spectators expect on the BR2 tab).
+ * - Rows present only in `paired` (e.g. an athlete who DNS'd run 2 but
+ *   ran run 1) are appended below, preserving the paired race's
+ *   `start_order` so they render in a sensible sequence.
+ *
+ * Each output row has both `run1StartTime` and `run2StartTime` populated;
+ * either may be `null` when the athlete only appears in one run.
+ */
+function mergeBrStartlists(
+  queried: StartlistEntry[],
+  paired: StartlistEntry[],
+  queriedRunCode: 'BR1' | 'BR2'
+): StartlistDisplayRow[] {
+  const pairedByKey = new Map<string, StartlistEntry>();
+  for (const entry of paired) {
+    pairedByKey.set(startlistMergeKey(entry), entry);
+  }
+
+  const seen = new Set<string>();
+  const rows: StartlistDisplayRow[] = [];
+
+  for (const entry of queried) {
+    const key = startlistMergeKey(entry);
+    seen.add(key);
+    const other = pairedByKey.get(key) ?? null;
+    rows.push({
+      ...entry,
+      run1StartTime:
+        queriedRunCode === 'BR1' ? entry.startTime : (other?.startTime ?? null),
+      run2StartTime:
+        queriedRunCode === 'BR2' ? entry.startTime : (other?.startTime ?? null),
+    });
+  }
+
+  // Append paired-only rows (athletes present only in the paired run).
+  for (const entry of paired) {
+    const key = startlistMergeKey(entry);
+    if (seen.has(key)) continue;
+    rows.push({
+      ...entry,
+      run1StartTime:
+        queriedRunCode === 'BR2' ? entry.startTime : null,
+      run2StartTime:
+        queriedRunCode === 'BR1' ? entry.startTime : null,
+    });
+  }
+
+  return rows;
+}
+
+/**
+ * Get startlist for a race, transparently merging both runs for BR races.
+ *
+ * - Non-BR race → identical to `getStartlist`.
+ * - BR race → fetches the paired BR run in parallel and unions by
+ *   athlete (see `mergeBrStartlists`). If the paired race fails (e.g.
+ *   not yet ingested), the response degrades gracefully to the
+ *   queried race's data only — `run1StartTime`/`run2StartTime` will
+ *   contain whatever is known.
+ */
+export async function getStartlistMaybeBr(
+  eventId: string,
+  raceId: string
+): Promise<StartlistDisplayRow[]> {
+  const pairedRaceId = getPairedBrRaceId(raceId);
+
+  if (!pairedRaceId) {
+    // Non-BR race: identity (rows have no run1/run2 fields).
+    return getStartlist(eventId, raceId);
+  }
+
+  const queriedRunCode: 'BR1' | 'BR2' = raceId.includes('_BR1_') ? 'BR1' : 'BR2';
+
+  const [queried, paired] = await Promise.all([
+    getStartlist(eventId, raceId),
+    getStartlist(eventId, pairedRaceId).catch(() => [] as StartlistEntry[]),
+  ]);
+
+  return mergeBrStartlists(queried, paired, queriedRunCode);
 }
 
 /**

--- a/packages/client/src/utils/groupRaces.test.ts
+++ b/packages/client/src/utils/groupRaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupRaces, type ClassGroup } from './groupRaces';
+import { groupRaces, getPairedBrRaceId, type ClassGroup } from './groupRaces';
 import type { RaceInfo } from '../services/api';
 
 /** Helper to create a minimal RaceInfo stub */
@@ -120,5 +120,36 @@ describe('groupRaces', () => {
       expect(groups[0].displayRaces[0].raceType).toBe('qualification');
       expect(groups[0].displayRaces[1].raceType).toBe('best-run-2');
     });
+  });
+});
+
+describe('getPairedBrRaceId', () => {
+  it('swaps BR1 → BR2', () => {
+    expect(getPairedBrRaceId('K1M_BR1_1')).toBe('K1M_BR2_1');
+  });
+
+  it('swaps BR2 → BR1', () => {
+    expect(getPairedBrRaceId('K1M_BR2_1')).toBe('K1M_BR1_1');
+  });
+
+  it('handles classId with underscores', () => {
+    expect(getPairedBrRaceId('K1M_ST_BR1_6')).toBe('K1M_ST_BR2_6');
+    expect(getPairedBrRaceId('K1M_ST_BR2_6')).toBe('K1M_ST_BR1_6');
+  });
+
+  it('handles non-numeric suffix', () => {
+    expect(getPairedBrRaceId('K1M_BR1_day1')).toBe('K1M_BR2_day1');
+  });
+
+  it('returns null for non-BR races', () => {
+    expect(getPairedBrRaceId('K1M_Q')).toBeNull();
+    expect(getPairedBrRaceId('K1M_F')).toBeNull();
+    expect(getPairedBrRaceId('K1M_HEAT_1')).toBeNull();
+  });
+
+  it('returns null for malformed BR ids', () => {
+    expect(getPairedBrRaceId('K1M_BR3_1')).toBeNull();
+    expect(getPairedBrRaceId('BR1_1')).toBeNull();
+    expect(getPairedBrRaceId('')).toBeNull();
   });
 });

--- a/packages/client/src/utils/groupRaces.ts
+++ b/packages/client/src/utils/groupRaces.ts
@@ -100,6 +100,25 @@ export function groupRaces(races: RaceInfo[]): ClassGroup[] {
 }
 
 /**
+ * Single source of truth for parsing BR race IDs.
+ * Format: {classId}_BR{N}_{suffix} where classId may contain underscores
+ * (e.g. K1M_ST_BR1_6 → classPrefix=K1M_ST, run=1, suffix=6).
+ */
+const BR_RACE_ID_PATTERN = /^(.+)_(BR[12])_(.+)$/;
+
+/**
+ * Given a BR race ID, return the paired run's race ID
+ * (BR1 ↔ BR2). Returns null if raceId is not a BR race.
+ */
+export function getPairedBrRaceId(raceId: string): string | null {
+  const match = raceId.match(BR_RACE_ID_PATTERN);
+  if (!match) return null;
+  const [, classPrefix, runCode, suffix] = match;
+  const pairedRunCode = runCode === 'BR1' ? 'BR2' : 'BR1';
+  return `${classPrefix}_${pairedRunCode}_${suffix}`;
+}
+
+/**
  * Filter races for tab display:
  * - When both best-run-1 and best-run-2 exist, hide BR1 (BR2 has combined data)
  * - Keeps all other race types
@@ -116,13 +135,12 @@ export function getDisplayRaces(races: RaceInfo[]): RaceInfo[] {
   const br2Races = filtered.filter((r) => r.raceType === 'best-run-2');
   if (br2Races.length <= 1) return filtered;
 
-  const br2Pattern = /^(.+)_BR[12]_(.+)$/;
   let bestBr2: RaceInfo | null = null;
   let bestSuffix = -1;
 
   for (const r of br2Races) {
-    const match = r.raceId.match(br2Pattern);
-    const suffix = match ? parseInt(match[2], 10) : 0;
+    const match = r.raceId.match(BR_RACE_ID_PATTERN);
+    const suffix = match ? parseInt(match[3], 10) : 0;
     if (suffix > bestSuffix) {
       bestSuffix = suffix;
       bestBr2 = r;


### PR DESCRIPTION
## Summary
- BR startlist now shows two columns "B1" / "B2" with both run scheduled start times per athlete.
- Client-side union merge — fetches both BR runs in parallel, joins by `athleteId` (fallback `bib|catId|name`).
- Fail-soft when paired run not yet ingested. Server, API contract and shared types untouched.

## Changes
- `packages/client/src/utils/groupRaces.ts` — `getPairedBrRaceId(raceId)` helper, single source of truth for BR1↔BR2 swap.
- `packages/client/src/services/api.ts` — `StartlistDisplayRow` display type, `mergeBrStartlists` (union, BR2 order first, BR1-only appended), `getStartlistMaybeBr` (transparent for non-BR, parallel-fetch + merge for BR).
- `packages/client/src/components/StartlistTable.tsx` — renders B1/B2 columns when rows include `run1StartTime`/`run2StartTime`; otherwise unchanged.
- `packages/client/src/pages/EventDetailPage.tsx` — uses `getStartlistMaybeBr` instead of `getStartlist`.

## Behavior
- **Non-BR race:** identical to before — single "Start" column.
- **BR race:** two "B1" / "B2" columns; rows ordered by the queried race's `start_order` (typically BR2's reverse-of-BR1 order — what spectators expect on the BR2 tab); BR1-only entries (e.g. DNS in run 2) appended below with `—` in the missing column.
- **Paired race not ingested:** 404 from the paired fetch is fail-soft — queried side still renders with `—` in the missing column. Errors on the primary (queried) race still propagate to the normal error UI.

## Why client-side
Startlist is static post-ingest, opened occasionally, not streamed via WS. Two parallel requests are effectively free, while server-side join would have meant: shared type churn, Fastify schema change, new repository method, new server integration test — all for a non-hot read. Validated by second-opinion review (Gemini + Claude Code, both independent, both agreed).

## Test plan
- [x] `npm test` — 187 tests, all green (added 13 new tests across `groupRaces`, `api`, `StartlistTable`).
- [x] `npm run -w @c123-live-mini/client typecheck` — clean.
- [x] `npm run build` — full monorepo build clean.
- [ ] Manual smoke: ingest BR XML on local server, open event detail BR tab, verify two columns at desktop and 360px viewport.
- [ ] Verify fail-soft: temporarily delete paired run from DB, confirm queried side still renders.

Closes #129