### PR TITLE
feat(client): auto-select current day on event open

### DIFF
--- a/packages/client/src/pages/EventDetailPage.tsx
+++ b/packages/client/src/pages/EventDetailPage.tsx
@@ -22,7 +22,7 @@ import {
   type CategoryInfo,
   type StartlistDisplayRow,
 } from '../services/api';
-import { groupRaces, extractDays, getDisplayRaces, type ClassGroup, type DayInfo } from '../utils/groupRaces';
+import { groupRaces, extractDays, getDisplayRaces, pickDefaultDay, type ClassGroup, type DayInfo } from '../utils/groupRaces';
 import { isBestRunRace } from '../utils/raceTypeLabels';
 import { EventHeader } from '../components/EventHeader';
 import { ClassTabs } from '../components/ClassTabs';
@@ -332,13 +332,15 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
         const dayInfos = extractDays(eventData.races);
         setDays(dayInfos);
 
-        // Auto-select active day
+        // Auto-select day on first load:
+        //   1. Today (if today is one of the event days) — most common at the venue
+        //   2. Day with a running race (raceStatus >= 2)
+        //   3. First upcoming day (event hasn't started yet)
+        //   4. First day (past event fallback)
         if (dayInfos.length > 1 && !dayAutoSelectedRef.current) {
           dayAutoSelectedRef.current = true;
-          const runningDay = dayInfos.find((d) =>
-            eventData.races.some((r) => d.raceIds.has(r.raceId) && r.raceStatus != null && r.raceStatus >= 2)
-          );
-          setSelectedDay(runningDay ? runningDay.date : dayInfos[0].date);
+          const defaultDay = pickDefaultDay(dayInfos, eventData.races);
+          if (defaultDay) setSelectedDay(defaultDay);
         }
 
         // Handle deep link with raceId from URL

--- a/packages/client/src/utils/groupRaces.test.ts
+++ b/packages/client/src/utils/groupRaces.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { groupRaces, getPairedBrRaceId, type ClassGroup } from './groupRaces';
+import {
+  groupRaces,
+  getPairedBrRaceId,
+  pickDefaultDay,
+  formatLocalDateYMD,
+  type ClassGroup,
+  type DayInfo,
+} from './groupRaces';
 import type { RaceInfo } from '../services/api';
 
 /** Helper to create a minimal RaceInfo stub */
@@ -151,5 +158,152 @@ describe('getPairedBrRaceId', () => {
     expect(getPairedBrRaceId('K1M_BR3_1')).toBeNull();
     expect(getPairedBrRaceId('BR1_1')).toBeNull();
     expect(getPairedBrRaceId('')).toBeNull();
+  });
+});
+
+describe('formatLocalDateYMD', () => {
+  it('formats local date as YYYY-MM-DD', () => {
+    const d = new Date(2026, 3, 22, 10, 30); // April 22, 2026 (month is 0-indexed)
+    expect(formatLocalDateYMD(d)).toBe('2026-04-22');
+  });
+
+  it('zero-pads single-digit month and day', () => {
+    const d = new Date(2026, 0, 5, 12, 0); // Jan 5, 2026
+    expect(formatLocalDateYMD(d)).toBe('2026-01-05');
+  });
+});
+
+describe('pickDefaultDay', () => {
+  /** Helper to make a DayInfo stub */
+  function makeDay(date: string, raceIds: string[] = []): DayInfo {
+    const [, m, day] = date.split('-');
+    return {
+      date,
+      label: `${parseInt(day)}.${parseInt(m)}.`,
+      raceIds: new Set(raceIds),
+    };
+  }
+
+  it('returns null for empty day list', () => {
+    expect(pickDefaultDay([], [])).toBeNull();
+  });
+
+  it("picks today when today's date matches a day", () => {
+    const days = [
+      makeDay('2026-04-21', ['race-day1']),
+      makeDay('2026-04-22', ['race-day2']),
+      makeDay('2026-04-23', ['race-day3']),
+    ];
+    const now = new Date(2026, 3, 22, 14, 0); // April 22
+    expect(pickDefaultDay(days, [], now)).toBe('2026-04-22');
+  });
+
+  it('picks today even if another day has a running race', () => {
+    const days = [
+      makeDay('2026-04-21', ['race-running']),
+      makeDay('2026-04-22', ['race-today']),
+    ];
+    const races: RaceInfo[] = [
+      {
+        raceId: 'race-running',
+        classId: 'K1M',
+        raceType: 'final',
+        raceOrder: 1,
+        raceStatus: 2,
+        startTime: null,
+      },
+      {
+        raceId: 'race-today',
+        classId: 'K1M',
+        raceType: 'final',
+        raceOrder: 2,
+        raceStatus: 0,
+        startTime: null,
+      },
+    ];
+    const now = new Date(2026, 3, 22, 10, 0);
+    expect(pickDefaultDay(days, races, now)).toBe('2026-04-22');
+  });
+
+  it('picks day with running race when today does not match', () => {
+    const days = [
+      makeDay('2026-04-20', ['race-idle']),
+      makeDay('2026-04-21', ['race-running']),
+    ];
+    const races: RaceInfo[] = [
+      {
+        raceId: 'race-idle',
+        classId: 'K1M',
+        raceType: 'final',
+        raceOrder: 1,
+        raceStatus: 0,
+        startTime: null,
+      },
+      {
+        raceId: 'race-running',
+        classId: 'K1M',
+        raceType: 'final',
+        raceOrder: 2,
+        raceStatus: 3,
+        startTime: null,
+      },
+    ];
+    const now = new Date(2026, 3, 22, 10, 0); // April 22 — no match
+    expect(pickDefaultDay(days, races, now)).toBe('2026-04-21');
+  });
+
+  it('picks first upcoming day when today is before the event', () => {
+    const days = [
+      makeDay('2026-05-01', ['race-d1']),
+      makeDay('2026-05-02', ['race-d2']),
+      makeDay('2026-05-03', ['race-d3']),
+    ];
+    const now = new Date(2026, 3, 22, 10, 0); // April 22 — before event
+    expect(pickDefaultDay(days, [], now)).toBe('2026-05-01');
+  });
+
+  it('picks first day when today is after the event (past event)', () => {
+    const days = [
+      makeDay('2026-04-10', ['race-d1']),
+      makeDay('2026-04-11', ['race-d2']),
+    ];
+    const now = new Date(2026, 3, 22, 10, 0); // April 22 — after event
+    expect(pickDefaultDay(days, [], now)).toBe('2026-04-10');
+  });
+
+  it('ignores raceStatus=1 (not yet running)', () => {
+    const days = [
+      makeDay('2026-04-20', ['race-pending']),
+      makeDay('2026-04-21', ['race-future']),
+    ];
+    const races: RaceInfo[] = [
+      {
+        raceId: 'race-pending',
+        classId: 'K1M',
+        raceType: 'final',
+        raceOrder: 1,
+        raceStatus: 1,
+        startTime: null,
+      },
+    ];
+    const now = new Date(2026, 3, 22, 10, 0);
+    // No today match, no running race — fall through to "first upcoming" (none), then first day
+    expect(pickDefaultDay(days, races, now)).toBe('2026-04-20');
+  });
+
+  it('handles single-day event (returned as empty by extractDays, but defensive)', () => {
+    const days = [makeDay('2026-04-22', ['race-only'])];
+    const now = new Date(2026, 3, 22, 10, 0);
+    expect(pickDefaultDay(days, [], now)).toBe('2026-04-22');
+  });
+
+  it('prefers today over upcoming when both could apply', () => {
+    // Today falls on first day of event; don't accidentally pick "upcoming" (second day).
+    const days = [
+      makeDay('2026-04-22', ['race-d1']),
+      makeDay('2026-04-23', ['race-d2']),
+    ];
+    const now = new Date(2026, 3, 22, 8, 0);
+    expect(pickDefaultDay(days, [], now)).toBe('2026-04-22');
   });
 });

--- a/packages/client/src/utils/groupRaces.ts
+++ b/packages/client/src/utils/groupRaces.ts
@@ -12,6 +12,57 @@ export interface DayInfo {
 }
 
 /**
+ * Format a Date as YYYY-MM-DD in the browser's local timezone.
+ * Matches the `date` field format produced by {@link extractDays}.
+ */
+export function formatLocalDateYMD(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * Pick the day to auto-select when the user opens a multi-day event.
+ *
+ * Priority:
+ *   1. Day whose date equals today (spectator at the venue — most common case).
+ *   2. Day containing a race that's currently running (`raceStatus >= 2`).
+ *   3. First upcoming day (today is before the event).
+ *   4. First day (today is after the event, or no other signal).
+ *
+ * @param days      Sorted list of event days (from {@link extractDays}). Must be non-empty.
+ * @param races     All races in the event (used to look up raceStatus for priority 2).
+ * @param now       Current time — injected for testability.
+ * @returns         `DayInfo.date` of the day to auto-select, or `null` if `days` is empty.
+ */
+export function pickDefaultDay(
+  days: DayInfo[],
+  races: RaceInfo[],
+  now: Date = new Date()
+): string | null {
+  if (days.length === 0) return null;
+
+  const today = formatLocalDateYMD(now);
+
+  // 1. Today matches one of the event days
+  const todayDay = days.find((d) => d.date === today);
+  if (todayDay) return todayDay.date;
+
+  // 2. A race is currently running on some day
+  const runningDay = days.find((d) =>
+    races.some(
+      (r) => d.raceIds.has(r.raceId) && r.raceStatus != null && r.raceStatus >= 2
+    )
+  );
+  if (runningDay) return runningDay.date;
+
+  // 3. First upcoming day (today is before the event — days are sorted ascending)
+  const upcomingDay = days.find((d) => d.date > today);
+  if (upcomingDay) return upcomingDay.date;
+
+  // 4. Fallback: first day
+  return days[0].date;
+}
+
+/**
  * Extract unique days from race startTimes.
  * Returns sorted array of DayInfo. If all races fall on same day, returns empty array.
  */


### PR DESCRIPTION
## Summary

Closes #161

When opening a multi-day event, the app now prefers **today's local date** as the default day instead of always defaulting to day 1 (or to a running race). Spectators at the venue on day 2/3 no longer have to tap the day selector.

### Behavior

Priority for `pickDefaultDay(days, races, now)`:

1. **Today** — if today's local YYYY-MM-DD matches one of the event's days (most common at the venue).
2. **Day with a running race** (`raceStatus >= 2`) — old behavior, now a fallback.
3. **First upcoming day** — today is before the event (event hasn't started).
4. **First day** — past event / no other signal.

Auto-pick only fires on first load (existing `dayAutoSelectedRef` guard). User clicks on day tabs are respected afterwards — no new persistence, no session memory added.

## Files changed

- `packages/client/src/utils/groupRaces.ts` — new pure `pickDefaultDay()` and helper `formatLocalDateYMD()`.
- `packages/client/src/pages/EventDetailPage.tsx` — replaced inline `find(running day)` branch with `pickDefaultDay()` call.
- `packages/client/src/utils/groupRaces.test.ts` — 11 new tests.

## Test plan

Unit tests (`npm test`) cover:
- [x] Today matches a day in the event -> picks today
- [x] Today matches even if another day has a running race (today wins)
- [x] Today does not match, running race on some day -> picks running day
- [x] Today is before event (`2026-04-22` vs `2026-05-01..03`) -> picks first upcoming
- [x] Today is after event (`2026-04-22` vs `2026-04-10..11`) -> picks first day
- [x] `raceStatus=1` is not counted as "running" (ignored)
- [x] Single-day list (defensive) -> returns that day
- [x] Priority: today over "first upcoming" when both could apply
- [x] Empty day list -> returns null
- [x] `formatLocalDateYMD` zero-pads month/day
- [x] `formatLocalDateYMD` formats a known date correctly
- [x] Full `npm run build` passes (TS strict)
- [x] Full `npm test` passes (210 tests, 2 skipped — no regressions)

## Decisions / open questions for review

1. **Timezone:** we use `new Date()` in the browser's local timezone. Events are held in Europe/Prague in practice. A spectator viewing the event from another timezone (e.g. at midnight local vs. Prague time) could see the "wrong" day auto-picked for one narrow window. Accepted edge case — deep links (`/race/:id`) always override.
2. **No localStorage of day choice** — the issue didn't ask for it and there was no existing persistence to collide with. Kept scope minimal.
3. **Running-race still wins over "upcoming"** — if today is outside the range but a race is somehow live (e.g. TZ offset puts the browser date behind/ahead of Prague), pick the running day rather than a nominally "upcoming" one. Intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)