### PR TITLE
fix(client): clear text filter on class/category switch

### DIFF
--- a/packages/client/src/components/ResultList.test.tsx
+++ b/packages/client/src/components/ResultList.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { ResultList } from './ResultList';
+import type { ResultEntry, ResultsResponse } from '../services/api';
+
+function result(overrides: Partial<ResultEntry> & { name: string }): ResultEntry {
+  return {
+    rnk: overrides.rnk ?? 1,
+    bib: overrides.bib ?? 1,
+    athleteId: overrides.athleteId ?? null,
+    name: overrides.name,
+    club: overrides.club ?? null,
+    noc: overrides.noc ?? null,
+    catId: overrides.catId ?? null,
+    catRnk: overrides.catRnk ?? null,
+    time: overrides.time ?? null,
+    pen: overrides.pen ?? null,
+    total: overrides.total ?? null,
+    totalBehind: overrides.totalBehind ?? null,
+    catTotalBehind: overrides.catTotalBehind ?? null,
+    status: overrides.status ?? null,
+  };
+}
+
+function buildData(): ResultsResponse {
+  return {
+    race: {
+      raceId: 'R1',
+      classId: 'K1M',
+      raceType: 'F',
+      raceStatus: 2,
+    },
+    results: [
+      result({ name: 'Alpha A.', bib: 1 }),
+      result({ name: 'Beta B.', bib: 2 }),
+    ],
+  };
+}
+
+describe('ResultList search reset behavior (#149)', () => {
+  afterEach(() => cleanup());
+
+  it('changing searchResetKey remounts the SearchInput so its internal value resets', () => {
+    const onSearchChange = vi.fn();
+    const { rerender } = render(
+      <ResultList
+        data={buildData()}
+        onSearchChange={onSearchChange}
+        searchResetKey="K1M|"
+      />
+    );
+
+    // Type into the uncontrolled SearchInput. The DS component debounces onChange
+    // (200ms by default in our wiring), so we just assert the DOM value here —
+    // that's what the bug was: DOM value lingered when state moved on.
+    const input = screen.getByPlaceholderText('Hledat závodníka...') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alp' } });
+    expect(input.value).toBe('alp');
+
+    // Simulate switching class/category — parent will pass a new searchResetKey.
+    rerender(
+      <ResultList
+        data={buildData()}
+        onSearchChange={onSearchChange}
+        searchResetKey="C1W|"
+      />
+    );
+
+    // A fresh input instance must be in the DOM (remounted via key change) with an
+    // empty value, so the user can see there is no active filter.
+    const inputAfter = screen.getByPlaceholderText('Hledat závodníka...') as HTMLInputElement;
+    expect(inputAfter.value).toBe('');
+  });
+
+  it('stable searchResetKey preserves user-typed text across rerenders', () => {
+    const onSearchChange = vi.fn();
+    const { rerender } = render(
+      <ResultList
+        data={buildData()}
+        onSearchChange={onSearchChange}
+        searchResetKey="K1M|"
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Hledat závodníka...') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'bet' } });
+    expect(input.value).toBe('bet');
+
+    // Unrelated rerender (same key) — DOM value must survive.
+    rerender(
+      <ResultList
+        data={buildData()}
+        onSearchChange={onSearchChange}
+        searchResetKey="K1M|"
+      />
+    );
+
+    const inputAfter = screen.getByPlaceholderText('Hledat závodníka...') as HTMLInputElement;
+    expect(inputAfter.value).toBe('bet');
+  });
+});
+
+// Silence unused-import warning in case React strict-mode debounce timers log.
+void act;

--- a/packages/client/src/components/ResultList.tsx
+++ b/packages/client/src/components/ResultList.tsx
@@ -299,6 +299,10 @@ interface ResultListProps {
   showRoundTabs?: boolean;
   // Search (uncontrolled — no value prop, just onChange callback)
   onSearchChange?: (q: string) => void;
+  /** Forces SearchInput to remount, resetting its uncontrolled internal value. Change this
+   *  when the filter context changes (e.g. class/category switch) so a stale query can't
+   *  stay in the DOM input while the parent state has moved on. See #149. */
+  searchResetKey?: string;
   // Category
   categories?: CategoryInfo[];
   onCategoryChange?: (catId: string | null) => void;
@@ -327,6 +331,7 @@ export function ResultList({
   hasMergedBR = false,
   showRoundTabs = false,
   onSearchChange,
+  searchResetKey,
   categories = [],
   onCategoryChange,
   isFavorite,
@@ -382,6 +387,7 @@ export function ResultList({
           {onSearchChange && (
             <div className={styles.searchWrapper}>
               <SearchInput
+                key={searchResetKey}
                 size="sm"
                 placeholder="Hledat závodníka..."
                 onChange={onSearchChange}

--- a/packages/client/src/pages/EventDetailPage.tsx
+++ b/packages/client/src/pages/EventDetailPage.tsx
@@ -490,6 +490,10 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
     (classId: string) => {
       setSelectedClassId(classId);
       setExpandedRows(new Set());
+      // Clear text filter so the search field stays in sync with the predicate (#149).
+      // Without this, switching classes leaves a stale filter applied to results but
+      // hides its value from the (uncontrolled) SearchInput, so the user can't clear it.
+      setSearchQuery('');
       const group = classGroups.find((g) => g.classId === classId);
       if (!group) return;
 
@@ -540,6 +544,8 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
   const handleCategoryChange = useCallback((catId: string | null) => {
     setSelectedCatId(catId);
     setExpandedRows(new Set());
+    // Clear text filter on category switch so it matches the visible input state (#149).
+    setSearchQuery('');
   }, []);
 
   // Handle row expand/collapse
@@ -851,6 +857,7 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
           hasMergedBR={hasMergedBR}
           showRoundTabs={showRoundTabs}
           onSearchChange={setSearchQuery}
+          searchResetKey={`${selectedClassId ?? ''}|${selectedCatId ?? ''}`}
           categories={availableCategories}
           onCategoryChange={handleCategoryChange}
           isFavorite={favorites.isFavorite}
@@ -865,6 +872,7 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
       {resultsState === 'success' && dataView === 'startlist' && (
         <div className={styles.startlistSearch}>
           <SearchInput
+            key={`startlist|${selectedClassId ?? ''}|${selectedCatId ?? ''}`}
             size="sm"
             placeholder="Hledat závodníka..."
             onChange={setSearchQuery}


### PR DESCRIPTION
## Summary

Fixes the stale-filter bug reported in #149: typing into the search field while viewing one category/class left the filter predicate active after switching, but wiped the visible text out of the `SearchInput`, leaving the user with no way to see or clear it.

## Root cause

`SearchInput` is intentionally used **uncontrolled** (per prior iteration-3 memory — a controlled `value` conflicts with the component's internal debounce and causes keystroke loss). Class/category changes only cleared `expandedRows`; they did not clear `searchQuery` state, and even if they did, an uncontrolled input keeps its DOM value. So the predicate silently re-applied to the new list and the input appeared empty.

## Fix

- In `EventDetailPage`, clear `searchQuery` inside `handleClassChange` and `handleCategoryChange` (mirrors the existing `handleDataViewChange` pattern).
- Pass a `searchResetKey` composed of `${selectedClassId}|${selectedCatId}` through to `ResultList`, which uses it as the `key` on the `SearchInput`. When the key changes, React remounts the component and its uncontrolled internal state also resets.
- Same `key` pattern applied to the Startovka `SearchInput` rendered directly in `EventDetailPage`.

No design-system changes, no inline styles, minimal surface area.

## Design decision / open question

Chose **(b) switching category clears the filter**, consistent with the existing data-view-switch behavior. Alternative (a) "preserve the filter text visibly across tabs" is plausible if a user wants to search the same surname across classes — but it requires making the input controlled, which reintroduces the debounce-conflict bug unless we rework the design-system integration. Happy to flip this in a follow-up if PM prefers (a).

## Files changed

- `packages/client/src/components/ResultList.tsx` — new `searchResetKey` prop threaded to `SearchInput`'s `key`.
- `packages/client/src/pages/EventDetailPage.tsx` — clear `searchQuery` on class/category change; derive and pass `searchResetKey`; apply same `key` to Startovka search.
- `packages/client/src/components/ResultList.test.tsx` — new test covering the remount-on-key-change behavior and the stable-key preservation case.

## Test plan

- [x] `npm run build` at repo root — clean (shared, server, client all typecheck + vite build OK)
- [x] `npx vitest run` in `packages/client` — 73/73 pass (2 new tests)
- [ ] Manual: on staging, type into the results search field, switch class → field is empty, results unfiltered.
- [ ] Manual: switch category via dropdown while filter active → same, field clears.
- [ ] Manual: switch data view (Výsledky ↔ Startovka) — unchanged behavior (already clears).

Closes #149