### PR TITLE
fix(client): force class tabs to own row below desktop breakpoint

### DIFF
--- a/packages/client/src/pages/EventDetailPage.module.css
+++ b/packages/client/src/pages/EventDetailPage.module.css
@@ -45,8 +45,10 @@
   flex: none;
 }
 
-/* Mobile: always standalone */
-@media (max-width: 640px) {
+/* Mobile + tablet/medium: always standalone.
+ * Below ~1024px the middle flex column is too narrow for pills to sit comfortably
+ * next to the day tabs and data-view tabs; force class tabs onto their own row. */
+@media (max-width: 1023px) {
   .classTabs {
     order: 10;
     width: 100%;


### PR DESCRIPTION
## Summary
- At medium viewport widths (641–1023px), the class-categories tabs on `EventDetailPage` were placed inline between the day-tabs and the data-view selector via `flex:1`. When the JS-computed standalone flag was false (total class-label characters ≤ 21), the middle flex column was too narrow at tablet widths and the class pills wrapped into 2–3 awkwardly-squeezed rows — exactly what issue #153 screenshots.
- Fix: extend the existing mobile standalone rule from `@media (max-width: 640px)` to `@media (max-width: 1023px)`. Below desktop width, class tabs always break onto their own full-width row. Desktop behaviour (≥1024px) is unchanged.

## Root cause
`packages/client/src/pages/EventDetailPage.module.css` — the `.classTabs` rule only forced `order:10; width:100%; flex:none` below 640px. The JS `classTabsStandalone` flag in `EventDetailPage.tsx` uses a character-count heuristic (`> 21`) that doesn't know the viewport width, so short class lists on tablet-sized screens were rendered inline and wrapped inside a ~200–400px middle column.

## Files changed
- `packages/client/src/pages/EventDetailPage.module.css` (+4 / -2) — widen the standalone media query.

## Before / After

Reproduced with `test-143` (15 classes with long names). To also reproduce the "short class list" bug the JS threshold was temporarily raised to force inline mode — screenshots from that reproduction:

| Viewport | Before (bug) | After (fix) |
|---|---|---|
| 695px (issue viewport) | `before-issue.png` | `after-695.png` |
| 768px | `before-repro-768.png` | `after-repro-768.png` |
| 900px | `before-repro-900.png` | `after-repro-900.png` |
| 1024px | `before-repro-1024.png` | `after-repro-1024.png` (unchanged — still inline as designed) |
| 1280px | — | `after-1280.png` (unchanged — standalone via char-count heuristic) |

Screenshots saved locally under `/tmp/153/`.

## Test plan
- [x] `npm run build` passes
- [x] `npm test -w @c123-live-mini/client` — 71 tests pass
- [x] `npm test -w @c123-live-mini/server` — 123 tests pass
- [x] Visual verification at 695/768/900/1024/1280px via Playwright
- [x] Design-system-only change (CSS module using existing breakpoint style, no new tokens)

Closes #153

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>