### PR TITLE
fix: route BR result to correct run column when only one run exists

### DIFF
--- a/packages/client/src/components/ResultList.tsx
+++ b/packages/client/src/components/ResultList.tsx
@@ -131,12 +131,34 @@ function buildStandardColumns(
   return cols;
 }
 
+/**
+ * Resolve BR run 1 / run 2 values from a row.
+ *
+ * Server convention: when both runs exist, `prev*` holds BR1 and `time/pen/total`
+ * holds BR2. When only one run exists, `prev*` is null and `time/pen/total` holds
+ * that single run — the `betterRunNr` field indicates whether it was run 1 or run 2.
+ */
+function resolveBrRuns(row: ResultEntry) {
+  const hasBothRuns = row.prevTotal != null;
+  if (hasBothRuns) {
+    return {
+      run1: { total: row.prevTotal ?? null, pen: row.prevPen ?? null },
+      run2: { total: row.total ?? null, pen: row.pen ?? null },
+    };
+  }
+  // Only one run exists — route by betterRunNr (primary slot holds that run).
+  const single = { total: row.total ?? null, pen: row.pen ?? null };
+  if (row.betterRunNr === 2) {
+    return { run1: { total: null, pen: null }, run2: single };
+  }
+  return { run1: single, run2: { total: null, pen: null } };
+}
+
 /** Mobile-only cell showing both BR runs stacked */
 function BrRunsCell({ row }: { row: ResultEntry }) {
   if (row.status) return <StatusBadge status={row.status} />;
 
-  const run1Total = row.prevTotal != null ? row.prevTotal : row.total;
-  const run2Total = row.prevTotal != null ? row.total : null;
+  const { run1, run2 } = resolveBrRuns(row);
   const isBetter1 = row.betterRunNr === 1;
   const isBetter2 = row.betterRunNr === 2;
 
@@ -144,17 +166,17 @@ function BrRunsCell({ row }: { row: ResultEntry }) {
     <div className={styles.brRunsStacked}>
       <div className={`${styles.brRunLine} ${isBetter1 ? styles.betterRun : ''}`}>
         <span className={styles.brRunLabel}>1.</span>
-        <span className={styles.monoText}>{formatTime(run1Total ?? null)}</span>
-        {row.prevPen != null && row.prevPen > 0 && (
-          <span className={styles.brRunPen}>({formatPenalty(row.prevTotal != null ? row.prevPen : row.pen)})</span>
+        <span className={styles.monoText}>{formatTime(run1.total)}</span>
+        {run1.pen != null && run1.pen > 0 && (
+          <span className={styles.brRunPen}>({formatPenalty(run1.pen)})</span>
         )}
       </div>
-      {run2Total !== null && (
+      {run2.total !== null && (
         <div className={`${styles.brRunLine} ${isBetter2 ? styles.betterRun : ''}`}>
           <span className={styles.brRunLabel}>2.</span>
-          <span className={styles.monoText}>{formatTime(run2Total)}</span>
-          {row.pen != null && row.pen > 0 && (
-            <span className={styles.brRunPen}>({formatPenalty(row.prevTotal != null ? row.pen : null)})</span>
+          <span className={styles.monoText}>{formatTime(run2.total)}</span>
+          {run2.pen != null && run2.pen > 0 && (
+            <span className={styles.brRunPen}>({formatPenalty(run2.pen)})</span>
           )}
         </div>
       )}
@@ -199,11 +221,12 @@ function buildBestRunColumns(
       hideOnMobile: true,
       render: (row) => {
         if (row.status) return <StatusBadge status={row.status} />;
-        const run1Total = row.prevTotal != null ? row.prevTotal : row.total;
+        const { run1 } = resolveBrRuns(row);
         const isBetter = row.betterRunNr === 1;
+        if (run1.total === null) return <span className={styles.monoText}>-</span>;
         return (
           <span className={`${styles.monoText} ${isBetter ? styles.betterRun : ''}`}>
-            {formatTime(run1Total ?? null)}
+            {formatTime(run1.total)}
           </span>
         );
       },
@@ -215,12 +238,12 @@ function buildBestRunColumns(
       hideOnMobile: true,
       render: (row) => {
         if (row.status) return null;
-        const run2Total = row.prevTotal != null ? row.total : null;
+        const { run2 } = resolveBrRuns(row);
         const isBetter = row.betterRunNr === 2;
-        if (run2Total === null) return <span className={styles.monoText}>-</span>;
+        if (run2.total === null) return <span className={styles.monoText}>-</span>;
         return (
           <span className={`${styles.monoText} ${isBetter ? styles.betterRun : ''}`}>
-            {formatTime(run2Total)}
+            {formatTime(run2.total)}
           </span>
         );
       },

--- a/packages/client/src/components/RunDetailExpand.tsx
+++ b/packages/client/src/components/RunDetailExpand.tsx
@@ -104,16 +104,33 @@ export function RunDetailExpand({ detail, isLoading, isBestRun, athleteName, bet
   }
 
   // BR race — always show two run blocks
-  // Server convention (chronological): detail.* = run 2 (BR2), detail.prev* = run 1 (BR1)
-  // betterRunNr indicates which run number was better
+  // Server convention: when both runs exist, detail.prev* = BR1 and detail.* = BR2.
+  // When only one run was ingested, detail.prev* is null and detail.* holds that
+  // single run — betterRunNr indicates whether it was run 1 or run 2 so the data
+  // can be routed into the correct block.
   if (isBestRun) {
-    const run1 = {
-      time: detail.prevTime ?? null,
-      pen: detail.prevPen ?? null,
-      total: detail.prevTotal ?? null,
-      gates: detail.prevGates ?? null,
-    };
-    const run2 = { time: detail.time, pen: detail.pen, total: detail.total, gates: detail.gates };
+    const hasBothRuns = detail.prevTotal != null;
+    const primary = { time: detail.time, pen: detail.pen, total: detail.total, gates: detail.gates };
+    const empty = { time: null, pen: null, total: null, gates: null };
+
+    let run1: { time: number | null; pen: number | null; total: number | null; gates: RunDetailData['gates'] };
+    let run2: { time: number | null; pen: number | null; total: number | null; gates: RunDetailData['gates'] };
+
+    if (hasBothRuns) {
+      run1 = {
+        time: detail.prevTime ?? null,
+        pen: detail.prevPen ?? null,
+        total: detail.prevTotal ?? null,
+        gates: detail.prevGates ?? null,
+      };
+      run2 = primary;
+    } else if (betterRunNr === 2) {
+      run1 = empty;
+      run2 = primary;
+    } else {
+      run1 = primary;
+      run2 = empty;
+    }
 
     const run1HasData = run1.total != null;
     const run2HasData = run2.total != null;

--- a/packages/client/src/utils/mapToResultsTable.test.ts
+++ b/packages/client/src/utils/mapToResultsTable.test.ts
@@ -82,6 +82,7 @@ describe('mapResultToDS', () => {
         total: 9400,
         prevTotal: null,
         totalTotal: null,
+        betterRunNr: 1,
       });
       const ds = mapResultToDS(result, true);
 
@@ -89,6 +90,27 @@ describe('mapResultToDS', () => {
       expect(ds.run1Penalty).toBe(2);
       expect(ds.run2Time).toBeUndefined();
       expect(ds.totalTime).toBe(94);       // falls back to total
+    });
+
+    // Regression test for issue #155: when a competitor only completed BR2
+    // (e.g. DNS in BR1), the primary slot carries Run 2 data and betterRunNr=2
+    // tells the mapper to route it into run2, not run1.
+    it('maps to run2 slot when only BR2 available (issue #155)', () => {
+      const result = makeResult({
+        time: 9200,
+        pen: 200,
+        total: 9400,
+        prevTotal: null,
+        totalTotal: 9400,
+        betterRunNr: 2,
+      });
+      const ds = mapResultToDS(result, true);
+
+      expect(ds.run1Time).toBeUndefined();
+      expect(ds.run1Penalty).toBeUndefined();
+      expect(ds.run2Time).toBe(92);
+      expect(ds.run2Penalty).toBe(2);
+      expect(ds.totalTime).toBe(94);
     });
   });
 

--- a/packages/client/src/utils/mapToResultsTable.ts
+++ b/packages/client/src/utils/mapToResultsTable.ts
@@ -86,10 +86,12 @@ export function mapResultToDS(
   let totalTime: number | undefined;
 
   if (isBestRun) {
-    // Server convention: primary run is BR2.
+    // Server convention: primary run is BR2 when both exist.
     //   result.time / result.pen / result.total  → Run 2 (current / primary)
     //   result.prevTime / result.prevPen / result.prevTotal → Run 1 (previous)
-    // When only BR1 has been run, prevTotal is null and total holds Run 1 data.
+    // When only one run has been ingested, prevTotal is null and the primary
+    // slot holds that single run — betterRunNr indicates which run it is so we
+    // can route the value to the correct run1/run2 column.
     const hasBothRuns = result.prevTotal != null;
 
     if (hasBothRuns) {
@@ -97,14 +99,18 @@ export function mapResultToDS(
       run1Penalty = hundredthsToSeconds(result.prevPen);
       run2Time = hundredthsToSeconds(result.time);
       run2Penalty = hundredthsToSeconds(result.pen);
+    } else if (result.betterRunNr === 2) {
+      // Only Run 2 available (athlete DNS'd Run 1) — map to run2 slot.
+      run2Time = hundredthsToSeconds(result.time);
+      run2Penalty = hundredthsToSeconds(result.pen);
     } else {
-      // Only Run 1 available — map to run1 slot.
+      // Only Run 1 available (or no clean run yet) — map to run1 slot.
       run1Time = hundredthsToSeconds(result.time);
       run1Penalty = hundredthsToSeconds(result.pen);
     }
 
     // Best-of-both-runs aggregate total (totalTotal), or fall back to the
-    // single-run total when BR2 hasn't been ingested yet.
+    // single-run total when only one run has been ingested yet.
     totalTime = hundredthsToSeconds(result.totalTotal ?? result.total);
   } else {
     // Single-run race: straightforward mapping.

--- a/packages/server/src/services/BrCombinedService.ts
+++ b/packages/server/src/services/BrCombinedService.ts
@@ -104,6 +104,12 @@ export class BrCombinedService {
       // Only show status (DSQ etc.) when NO clean run exists
       const combinedStatus = betterRunNr != null ? null : (infoSource.status || null);
 
+      // Primary slot holds the single existing run when only one ran (BR1 or BR2),
+      // and BR2 when both ran. The run number carried in the primary slot is
+      // disambiguated by betterRunNr when only one run exists, so the client
+      // can route the value into the correct run1/run2 column.
+      const primarySource = hasBothRuns ? br2! : infoSource;
+
       const entry: CombinedBrResult = {
         rnk: null, // will be recalculated
         bib: infoSource.bib,
@@ -113,10 +119,10 @@ export class BrCombinedService {
         noc: infoSource.noc,
         catId: infoSource.cat_id,
         catRnk: null, // will be recalculated
-        // Primary run: BR2 when both exist, else BR1
-        time: hasBothRuns ? (br2!.time ?? null) : (br1?.time ?? null),
-        pen: hasBothRuns ? (br2!.pen ?? null) : (br1?.pen ?? null),
-        total: hasBothRuns ? (br2!.total ?? null) : (br1?.total ?? null),
+        // Primary run: BR2 when both exist, else whichever single run was ingested
+        time: primarySource.time ?? null,
+        pen: primarySource.pen ?? null,
+        total: primarySource.total ?? null,
         totalBehind: null, // will be recalculated
         catTotalBehind: null, // will be recalculated
         status: combinedStatus,
@@ -129,12 +135,13 @@ export class BrCombinedService {
         prevRnk: hasBothRuns ? (br1!.rnk ?? null) : null,
       };
 
-      // Attach gate data — same chronological convention as times: primary=BR2, prev=BR1
+      // Attach gate data — mirrors the primary/prev convention above:
+      //   primary = BR2 when both exist, else the single ingested run (BR1 or BR2)
+      //   prev    = BR1 when both exist, null when only one run ran
       if (includeGates) {
-        const run2 = hasBothRuns ? br2 : (br1 ?? null);
-        entry.dtStart = run2?.dt_start ?? null;
-        entry.dtFinish = run2?.dt_finish ?? null;
-        entry.gates = parseGates(run2?.gates);
+        entry.dtStart = primarySource.dt_start ?? null;
+        entry.dtFinish = primarySource.dt_finish ?? null;
+        entry.gates = parseGates(primarySource.gates);
 
         const run1 = hasBothRuns ? br1 : null;
         entry.prevDtStart = run1?.dt_start ?? null;

--- a/packages/server/tests/unit/BrCombinedService.test.ts
+++ b/packages/server/tests/unit/BrCombinedService.test.ts
@@ -217,6 +217,28 @@ describe('BrCombinedService', () => {
     expect(results[0].prevPen).toBeNull();
   });
 
+  // Regression test for issue #155: when a competitor runs only BR2 (e.g. DNS in
+  // BR1), the combined entry must carry BR2 data in the primary slot so the client
+  // can render it in the 2nd-run column (betterRunNr=2 disambiguates).
+  it('should handle single run only (BR2 exists, no BR1) — issue #155', async () => {
+    await seedResults('P1', null, { time: 8800, pen: 400, total: 9200 });
+
+    const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+    expect(results).toHaveLength(1);
+    // Primary slot carries the only existing run (BR2).
+    expect(results[0].time).toBe(8800);
+    expect(results[0].pen).toBe(400);
+    expect(results[0].total).toBe(9200);
+    expect(results[0].totalTotal).toBe(9200);
+    // betterRunNr=2 signals to the client that the primary slot holds Run 2.
+    expect(results[0].betterRunNr).toBe(2);
+    // prev* must be null — BR1 did not run.
+    expect(results[0].prevTime).toBeNull();
+    expect(results[0].prevPen).toBeNull();
+    expect(results[0].prevTotal).toBeNull();
+  });
+
   it('should handle DSQ on one run — use other run as best', async () => {
     // P1: BR1=DSQ, BR2=9000 → BR2 is the only clean run
     await seedResults('P1',


### PR DESCRIPTION
## Summary
When a competitor ran only BR2 (e.g. DNS in BR1 then ran the second heat), the combined BR result appeared in the **Run 1** column of the ResultList, with Run 2 shown as empty. Root cause was a two-sided bug: the server dropped the BR2 data into oblivion when BR1 was missing, and the client used `prevTotal == null` as a proxy for \"single run = Run 1\" without consulting `betterRunNr`.

## Fix
**Server (`BrCombinedService`):** the primary slot (`time`/`pen`/`total`, plus `dtStart`/`dtFinish`/`gates`) now carries whichever single run was ingested when only one is present, instead of reaching for `br1` unconditionally. `prev*` stays null when only one run exists. `betterRunNr` (already computed correctly) disambiguates which run number the primary slot represents.

**Client (`ResultList`, `mapToResultsTable`, `RunDetailExpand`):** when `prevTotal` is null, consult `betterRunNr` to decide whether the primary slot belongs in the Run 1 or Run 2 column. Shared helper `resolveBrRuns` in `ResultList.tsx` keeps the two BR cell renderers consistent.

Before (server, only-BR2 case): `time = br1?.time ?? null` → `null`. The BR2 data was discarded entirely.
After: `time = primarySource.time ?? null` where `primarySource = hasBothRuns ? br2 : infoSource`.

## Test plan
- [x] Added server unit test `should handle single run only (BR2 exists, no BR1) — issue #155` in `BrCombinedService.test.ts` verifying `time/pen/total/totalTotal` carry BR2 data and `betterRunNr === 2`.
- [x] Added client unit test `maps to run2 slot when only BR2 available (issue #155)` in `mapToResultsTable.test.ts`.
- [x] Full server suite: 124 passing, 2 skipped.
- [x] Full client suite: 72 passing.
- [x] `tsc --noEmit` clean for both packages.
- [ ] Manual smoke on staging after deploy: ingest a competitor with only BR2 data and confirm the time renders in the 2nd-run column on both desktop and mobile views, including the expanded detail panel.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)