### PR TITLE
fix(server): surface per-run DNF/DNS status in BR combined results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5586,7 +5586,7 @@
     },
     "packages/client": {
       "name": "@c123-live-mini/client",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@c123-live-mini/shared": "*",
         "@czechcanoe/rvp-design-system": "latest",
@@ -5609,7 +5609,7 @@
     },
     "packages/server": {
       "name": "@c123-live-mini/server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@c123-live-mini/shared": "*",
         "@fastify/static": "^8.3.0",
@@ -5630,7 +5630,7 @@
     },
     "packages/shared": {
       "name": "@c123-live-mini/shared",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "devDependencies": {
         "typescript": "^5.7.3"
       }

--- a/packages/client/src/components/ResultList.br-status.test.tsx
+++ b/packages/client/src/components/ResultList.br-status.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for #162 — per-run DNF/DNS visibility in BR combined
+ * results. The combined `status` field is cleared to null as soon as a
+ * participant has at least one clean run, which previously caused the
+ * client to fall back to displaying the wrong time (e.g. BR2's time on
+ * the Run 1 row) or an empty dash instead of the correct DNF badge.
+ *
+ * The server now surfaces `prevStatus` (BR1) and `currStatus` (BR2)
+ * separately on BR results; this suite verifies the client renders each
+ * run cell independently.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ResultList } from './ResultList';
+import type { ResultEntry, ResultsResponse } from '../services/api';
+
+function row(overrides: Partial<ResultEntry> & { name: string }): ResultEntry {
+  return {
+    rnk: overrides.rnk ?? null,
+    bib: overrides.bib ?? null,
+    athleteId: overrides.athleteId ?? null,
+    name: overrides.name,
+    club: overrides.club ?? null,
+    noc: overrides.noc ?? null,
+    catId: overrides.catId ?? null,
+    catRnk: overrides.catRnk ?? null,
+    time: overrides.time ?? null,
+    pen: overrides.pen ?? null,
+    total: overrides.total ?? null,
+    totalBehind: overrides.totalBehind ?? null,
+    catTotalBehind: overrides.catTotalBehind ?? null,
+    status: overrides.status ?? null,
+    // Multi-run fields
+    betterRunNr: overrides.betterRunNr,
+    totalTotal: overrides.totalTotal,
+    prevTime: overrides.prevTime,
+    prevPen: overrides.prevPen,
+    prevTotal: overrides.prevTotal,
+    prevRnk: overrides.prevRnk,
+    prevStatus: overrides.prevStatus,
+    currStatus: overrides.currStatus,
+  };
+}
+
+function wrap(entries: ResultEntry[]): ResultsResponse {
+  return {
+    race: { raceId: 'K1M_ST_BR2_6', classId: 'K1M_ST', raceType: 'best-run-2', raceStatus: 3 },
+    results: entries,
+  };
+}
+
+describe('ResultList — BR per-run status (#162)', () => {
+  afterEach(() => cleanup());
+
+  it('renders DNF badge in Run 1 cell when BR1 was DNF but BR2 was clean', () => {
+    render(
+      <ResultList
+        isBestRun
+        data={wrap([
+          row({
+            name: 'Novak J.',
+            bib: 1,
+            rnk: 1,
+            total: 9000,   // BR2 primary
+            totalTotal: 9000,
+            betterRunNr: 2,
+            prevTotal: null,   // BR1 had no total (DNF)
+            prevStatus: 'DNF', // BR1 DNF
+            status: null,      // combined cleared by BR2 clean
+            currStatus: null,
+          }),
+        ])}
+      />
+    );
+
+    // Desktop Run 1 cell should show a "DNF" badge; Run 2 cell should
+    // show the clean BR2 time (90.00). Before the fix Run 1 showed the
+    // BR2 time (90.00) and Run 2 showed "-".
+    expect(screen.getAllByText('DNF').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('90.00').length).toBeGreaterThan(0);
+  });
+
+  it('renders DNF badge in Run 2 cell when BR2 was DNF but BR1 was clean', () => {
+    render(
+      <ResultList
+        isBestRun
+        data={wrap([
+          row({
+            name: 'Novak J.',
+            bib: 1,
+            rnk: 1,
+            total: null,     // BR2 DNF, no total
+            totalTotal: 10866,
+            betterRunNr: 1,
+            prevTotal: 10866, // BR1 clean
+            prevStatus: null,
+            status: null,
+            currStatus: 'DNF',
+          }),
+        ])}
+      />
+    );
+
+    // Run 2 should show "DNF" badge; Run 1 should show 108.66 (BR1 time).
+    expect(screen.getAllByText('DNF').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('108.66').length).toBeGreaterThan(0);
+  });
+
+  it('renders DNS badge for BR1-only case when BR2 row does not exist yet', () => {
+    render(
+      <ResultList
+        isBestRun
+        data={wrap([
+          row({
+            name: 'Novak J.',
+            bib: 1,
+            rnk: null,
+            total: null,
+            totalTotal: null,
+            betterRunNr: null,
+            prevTotal: null,
+            prevStatus: null,       // BR2 doesn't exist; no "prev" to have status
+            status: 'DNS',          // combined falls back to single-run status
+            currStatus: 'DNS',      // mirrors infoSource (BR1) when only BR1
+          }),
+        ])}
+      />
+    );
+
+    expect(screen.getAllByText('DNS').length).toBeGreaterThan(0);
+  });
+
+  it('shows Run 1 time and nothing (or "-") for Run 2 when only BR1 has run (clean)', () => {
+    render(
+      <ResultList
+        isBestRun
+        data={wrap([
+          row({
+            name: 'Novak J.',
+            bib: 1,
+            rnk: 1,
+            total: 8500,
+            totalTotal: 8500,
+            betterRunNr: 1,
+            prevTotal: null,    // no previous run
+            prevStatus: null,
+            currStatus: null,
+            status: null,
+          }),
+        ])}
+      />
+    );
+
+    // Run 1 shows the BR1 time (85.00). Run 2 shows a dash.
+    expect(screen.getAllByText('85.00').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('90.00').length).toBe(0);
+  });
+});

--- a/packages/client/src/components/ResultList.tsx
+++ b/packages/client/src/components/ResultList.tsx
@@ -133,10 +133,21 @@ function buildStandardColumns(
 
 /** Mobile-only cell showing both BR runs stacked */
 function BrRunsCell({ row }: { row: ResultEntry }) {
-  if (row.status) return <StatusBadge status={row.status} />;
-
-  const run1Total = row.prevTotal != null ? row.prevTotal : row.total;
-  const run2Total = row.prevTotal != null ? row.total : null;
+  // #162: Use per-run status fields so each run's DNF/DNS is shown in its
+  // own line even when the combined `status` was cleared by a clean run.
+  const br1Status = row.prevStatus ?? null;
+  const br2Status = row.currStatus ?? null;
+  // `prevTotal != null` used to mean "both runs exist". That's wrong when
+  // BR1 DNF'd (prevTotal=null but BR1 row still exists). Treat BR1 as
+  // present when either its total OR its status is populated.
+  const hasBr1 = row.prevTotal != null || br1Status != null;
+  // When BR2 doesn't exist, the "current" row IS BR1 — display status and
+  // total from the primary fields for Run 1 instead of prev.
+  const br1StatusForRun1 = hasBr1 ? br1Status : br2Status;
+  const run1Total = hasBr1 ? row.prevTotal : row.total;
+  const run1Pen = hasBr1 ? row.prevPen : row.pen;
+  const run2Total = hasBr1 ? row.total : null;
+  const run2HasData = hasBr1 && (run2Total != null || br2Status != null);
   const isBetter1 = row.betterRunNr === 1;
   const isBetter2 = row.betterRunNr === 2;
 
@@ -144,17 +155,29 @@ function BrRunsCell({ row }: { row: ResultEntry }) {
     <div className={styles.brRunsStacked}>
       <div className={`${styles.brRunLine} ${isBetter1 ? styles.betterRun : ''}`}>
         <span className={styles.brRunLabel}>1.</span>
-        <span className={styles.monoText}>{formatTime(run1Total ?? null)}</span>
-        {row.prevPen != null && row.prevPen > 0 && (
-          <span className={styles.brRunPen}>({formatPenalty(row.prevTotal != null ? row.prevPen : row.pen)})</span>
+        {br1StatusForRun1 ? (
+          <StatusBadge status={br1StatusForRun1} />
+        ) : (
+          <>
+            <span className={styles.monoText}>{formatTime(run1Total ?? null)}</span>
+            {run1Pen != null && run1Pen > 0 && (
+              <span className={styles.brRunPen}>({formatPenalty(run1Pen)})</span>
+            )}
+          </>
         )}
       </div>
-      {run2Total !== null && (
+      {run2HasData && (
         <div className={`${styles.brRunLine} ${isBetter2 ? styles.betterRun : ''}`}>
           <span className={styles.brRunLabel}>2.</span>
-          <span className={styles.monoText}>{formatTime(run2Total)}</span>
-          {row.pen != null && row.pen > 0 && (
-            <span className={styles.brRunPen}>({formatPenalty(row.prevTotal != null ? row.pen : null)})</span>
+          {br2Status ? (
+            <StatusBadge status={br2Status} />
+          ) : (
+            <>
+              <span className={styles.monoText}>{formatTime(run2Total ?? null)}</span>
+              {row.pen != null && row.pen > 0 && (
+                <span className={styles.brRunPen}>({formatPenalty(row.pen)})</span>
+              )}
+            </>
           )}
         </div>
       )}
@@ -198,12 +221,22 @@ function buildBestRunColumns(
       align: 'right',
       hideOnMobile: true,
       render: (row) => {
-        if (row.status) return <StatusBadge status={row.status} />;
-        const run1Total = row.prevTotal != null ? row.prevTotal : row.total;
+        // #162: Use per-run status so BR1 DNF/DNS is shown in its own cell
+        // instead of falling back to row.total (which may be BR2's time
+        // when BR1 DNF'd and BR2 is clean).
+        const br1Status = row.prevStatus ?? null;
+        const br2Status = row.currStatus ?? null;
+        const hasBr1 = row.prevTotal != null || br1Status != null;
+        // When BR2 doesn't exist, the "current" row IS BR1 — use currStatus
+        // and row.total for it instead of trying to pull from prev.
+        const br1StatusForRun1 = hasBr1 ? br1Status : br2Status;
+        if (br1StatusForRun1) return <StatusBadge status={br1StatusForRun1} />;
+        const run1Total = hasBr1 ? row.prevTotal : row.total;
         const isBetter = row.betterRunNr === 1;
+        if (run1Total == null) return <span className={styles.monoText}>-</span>;
         return (
           <span className={`${styles.monoText} ${isBetter ? styles.betterRun : ''}`}>
-            {formatTime(run1Total ?? null)}
+            {formatTime(run1Total)}
           </span>
         );
       },
@@ -214,10 +247,17 @@ function buildBestRunColumns(
       align: 'right',
       hideOnMobile: true,
       render: (row) => {
-        if (row.status) return null;
-        const run2Total = row.prevTotal != null ? row.total : null;
+        // #162: Use per-run status so BR2 DNF/DNS is shown in its own cell
+        // even when the combined `status` was cleared by a clean BR1.
+        const br1Status = row.prevStatus ?? null;
+        const br2Status = row.currStatus ?? null;
+        const hasBr1 = row.prevTotal != null || br1Status != null;
+        // When only BR1 has been run, there is no Run 2 to render.
+        if (!hasBr1) return <span className={styles.monoText}>-</span>;
+        if (br2Status) return <StatusBadge status={br2Status} />;
+        const run2Total = row.total;
         const isBetter = row.betterRunNr === 2;
-        if (run2Total === null) return <span className={styles.monoText}>-</span>;
+        if (run2Total == null) return <span className={styles.monoText}>-</span>;
         return (
           <span className={`${styles.monoText} ${isBetter ? styles.betterRun : ''}`}>
             {formatTime(run2Total)}

--- a/packages/client/src/components/ResultList.tsx
+++ b/packages/client/src/components/ResultList.tsx
@@ -514,6 +514,8 @@ export function ResultList({
                           isBestRun={isBestRun}
                           athleteName={row.name}
                           betterRunNr={row.betterRunNr}
+                          prevStatus={row.prevStatus}
+                          currStatus={row.currStatus}
                         />
                       </td>
                     </tr>

--- a/packages/client/src/components/RunDetailExpand.tsx
+++ b/packages/client/src/components/RunDetailExpand.tsx
@@ -18,6 +18,11 @@ interface RunDetailExpandProps {
   isBestRun?: boolean;
   athleteName?: string;
   betterRunNr?: number | null;
+  // Per-run status (#162): when set, render DNS/DNF/DSQ in place of
+  // time/total. Distinguishes "run attempted but didn't finish" from
+  // "run hasn't happened yet" (both-null → dashed placeholder).
+  prevStatus?: string | null;
+  currStatus?: string | null;
 }
 
 function TimeBreakdown({ time, pen, total }: {
@@ -67,25 +72,25 @@ function RunBlock({ label, isBetter, time, pen, total, gates }: {
   );
 }
 
-function RunPlaceholder({ label }: { label: string }) {
+function RunPlaceholder({ label, status }: { label: string; status?: string | null }) {
   return (
     <div className={`${styles.runSection} ${styles.runSectionPlaceholder}`}>
       <div className={styles.runSectionLabel}>{label}</div>
       <div className={styles.timeBreakdown}>
         <div className={styles.timeItem}>
           <span className={styles.timeLabel}>Čas</span>
-          <span className={styles.timeValue}>-</span>
+          <span className={styles.timeValue}>{status ?? '-'}</span>
         </div>
         <div className={styles.timeItem}>
           <span className={styles.timeLabel}>Celkem</span>
-          <span className={styles.timeValue}>-</span>
+          <span className={styles.timeValue}>{status ?? '-'}</span>
         </div>
       </div>
     </div>
   );
 }
 
-export function RunDetailExpand({ detail, isLoading, isBestRun, athleteName, betterRunNr }: RunDetailExpandProps) {
+export function RunDetailExpand({ detail, isLoading, isBestRun, athleteName, betterRunNr, prevStatus, currStatus }: RunDetailExpandProps) {
   if (isLoading) {
     return (
       <div className={styles.container}>
@@ -125,12 +130,12 @@ export function RunDetailExpand({ detail, isLoading, isBestRun, athleteName, bet
           {run1HasData ? (
             <RunBlock label="1. jízda" isBetter={betterRunNr === 1} time={run1.time} pen={run1.pen} total={run1.total} gates={run1.gates} />
           ) : (
-            <RunPlaceholder label="1. jízda" />
+            <RunPlaceholder label="1. jízda" status={prevStatus} />
           )}
           {run2HasData ? (
             <RunBlock label="2. jízda" isBetter={betterRunNr === 2} time={run2.time} pen={run2.pen} total={run2.total} gates={run2.gates} />
           ) : (
-            <RunPlaceholder label="2. jízda" />
+            <RunPlaceholder label="2. jízda" status={currStatus} />
           )}
         </div>
       </div>

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -86,6 +86,12 @@ export interface ResultEntry extends PublicResult {
   prevPen?: number | null;
   prevTotal?: number | null;
   prevRnk?: number | null;
+  // Per-run status fields for BR combined results (#162).
+  // `status` is the combined status (null when any clean run exists);
+  // these carry per-run status so the Run 1 / Run 2 cells can render
+  // DNF/DNS badges independently.
+  prevStatus?: string | null;
+  currStatus?: string | null;
   // Detailed fields (when detailed=true)
   dtStart?: string | null;
   dtFinish?: string | null;

--- a/packages/server/src/routes/ingest.ts
+++ b/packages/server/src/routes/ingest.ts
@@ -418,6 +418,34 @@ export function registerIngestRoutes(
               // BR race: compute combined results and broadcast for both BR1/BR2
               const combinedResults = await brCombinedService.computeCombined(eventDbId, race.race_id);
 
+              // Map to public payload — include per-run status (#162) so the
+              // client can render Run 1 / Run 2 cells independently even when
+              // the combined `status` is cleared by one clean run.
+              const publicBrResults = combinedResults.map((r) => ({
+                rnk: r.rnk,
+                bib: r.bib,
+                athleteId: r.athleteId,
+                name: r.name,
+                club: r.club,
+                noc: r.noc,
+                catId: r.catId,
+                catRnk: r.catRnk,
+                time: r.time,
+                pen: r.pen,
+                total: r.total,
+                totalBehind: r.totalBehind,
+                catTotalBehind: r.catTotalBehind,
+                status: r.status,
+                prevStatus: r.prevStatus,
+                currStatus: r.currStatus,
+                betterRunNr: r.betterRunNr,
+                totalTotal: r.totalTotal,
+                prevTime: r.prevTime,
+                prevPen: r.prevPen,
+                prevTotal: r.prevTotal,
+                prevRnk: r.prevRnk,
+              }));
+
               // Derive both BR1 and BR2 raceIds using regex (classId may contain underscores)
               const brMatch = race.race_id.match(/^(.+)_(BR[12])_(.+)$/);
               const br1RaceId = brMatch ? `${brMatch[1]}_BR1_${brMatch[3]}` : race.race_id;
@@ -426,12 +454,12 @@ export function registerIngestRoutes(
               // Broadcast combined data for both BR1 and BR2 raceIds
               // so clients viewing either run get correct combined data
               wsManager.broadcastDiff(eventId, {
-                results: combinedResults,
+                results: publicBrResults,
                 raceId: br1RaceId,
               });
               if (br1RaceId !== br2RaceId) {
                 wsManager.broadcastDiff(eventId, {
-                  results: combinedResults,
+                  results: publicBrResults,
                   raceId: br2RaceId,
                 });
               }

--- a/packages/server/src/routes/results.ts
+++ b/packages/server/src/routes/results.ts
@@ -40,6 +40,9 @@ interface ResultEntry {
   prevPen?: number | null;
   prevTotal?: number | null;
   prevRnk?: number | null;
+  // Per-run status fields for BR combined results (#162)
+  prevStatus?: string | null;
+  currStatus?: string | null;
   // Previous run detailed fields (BR with detailed=true)
   prevDtStart?: string | null;
   prevDtFinish?: string | null;
@@ -203,6 +206,8 @@ export function registerResultsRoutes(
             totalBehind: r.totalBehind,
             catTotalBehind: r.catTotalBehind,
             status: r.status,
+            prevStatus: r.prevStatus,
+            currStatus: r.currStatus,
             betterRunNr: r.betterRunNr,
             totalTotal: r.totalTotal,
             prevTime: r.prevTime,

--- a/packages/server/src/schemas/index.ts
+++ b/packages/server/src/schemas/index.ts
@@ -213,6 +213,9 @@ export const resultsSchema = {
               prevPen: { type: ['integer', 'null'] },
               prevTotal: { type: ['integer', 'null'] },
               prevRnk: { type: ['integer', 'null'] },
+              // Per-run status fields for BR combined results (#162)
+              prevStatus: { type: ['string', 'null'] },
+              currStatus: { type: ['string', 'null'] },
               // Previous run detailed fields (BR with detailed=true)
               prevDtStart: { type: ['string', 'null'] },
               prevDtFinish: { type: ['string', 'null'] },

--- a/packages/server/src/services/BrCombinedService.ts
+++ b/packages/server/src/services/BrCombinedService.ts
@@ -15,7 +15,27 @@ export interface CombinedBrResult {
   total: number | null;
   totalBehind: string | null;
   catTotalBehind: string | null;
+  /**
+   * Combined row status — cleared to `null` as soon as the participant has
+   * at least one clean run (so they stay rankable). Only populated when
+   * BOTH runs are DNF/DNS/DSQ (or the single existing run is). Used for
+   * the overall row badge and for sort/rank behaviour.
+   */
   status: string | null;
+  /**
+   * Status of BR1 specifically, regardless of BR2.
+   * `null` when BR1 was clean OR when BR1 does not yet exist.
+   * Use this to render the Run 1 cell independently of the combined status.
+   * (#162)
+   */
+  prevStatus: string | null;
+  /**
+   * Status of BR2 when both runs exist; when only BR1 exists this mirrors
+   * BR1's status (there is no "previous" run to distinguish).
+   * Use this to render the Run 2 cell independently of the combined status.
+   * (#162)
+   */
+  currStatus: string | null;
   betterRunNr: number | null;
   totalTotal: number | null;
   prevTime: number | null;
@@ -104,6 +124,16 @@ export class BrCombinedService {
       // Only show status (DSQ etc.) when NO clean run exists
       const combinedStatus = betterRunNr != null ? null : (infoSource.status || null);
 
+      // #162: Per-run status fields. The combined `status` above is cleared
+      // to null as soon as a participant has one clean run, which makes the
+      // client unable to distinguish "BR1 DNF + BR2 clean" from
+      // "only BR2 ran". prevStatus/currStatus surface the raw per-run status
+      // so the Run 1 / Run 2 cells can be rendered independently.
+      const prevStatus: string | null = hasBothRuns ? (br1!.status || null) : null;
+      const currStatus: string | null = hasBothRuns
+        ? (br2!.status || null)
+        : (infoSource.status || null);
+
       const entry: CombinedBrResult = {
         rnk: null, // will be recalculated
         bib: infoSource.bib,
@@ -120,6 +150,8 @@ export class BrCombinedService {
         totalBehind: null, // will be recalculated
         catTotalBehind: null, // will be recalculated
         status: combinedStatus,
+        prevStatus,
+        currStatus,
         betterRunNr,
         totalTotal,
         // Previous run: BR1 data when both exist, null when only one run

--- a/packages/server/tests/integration/br-per-run-status.test.ts
+++ b/packages/server/tests/integration/br-per-run-status.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration test for #162 — per-run DNF/DNS status in BR combined results.
+ *
+ * Verifies the fields `prevStatus` and `currStatus` make it through the
+ * GET /api/v1/events/:eventId/results/:raceId endpoint (including the
+ * Fastify response schema) when querying a BR2 race.
+ *
+ * Before the fix, the client relied on `prevTotal` as a proxy for
+ * "both runs exist" and had no signal at all for per-run DNF, so a BR1
+ * DNF + BR2 clean row rendered with Run 1 showing BR2's time and Run 2
+ * showing a dash.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { Kysely, SqliteDialect } from 'kysely';
+import Database from 'better-sqlite3';
+import type { Database as DatabaseSchema } from '../../src/db/schema.js';
+import { registerResultsRoutes } from '../../src/routes/results.js';
+
+describe('#162 — per-run DNF/DNS surfaces through the results API', () => {
+  let app: FastifyInstance;
+  let db: Kysely<DatabaseSchema>;
+  let eventId: number;
+
+  beforeEach(async () => {
+    const dialect = new SqliteDialect({ database: new Database(':memory:') });
+    db = new Kysely<DatabaseSchema>({ dialect });
+
+    await db.schema.createTable('events')
+      .addColumn('id', 'integer', c => c.primaryKey().autoIncrement())
+      .addColumn('event_id', 'text', c => c.notNull().unique())
+      .addColumn('main_title', 'text', c => c.notNull())
+      .addColumn('status', 'text', c => c.notNull().defaultTo('draft'))
+      .addColumn('has_xml_data', 'integer', c => c.notNull().defaultTo(0))
+      .addColumn('created_at', 'text', c => c.defaultTo('2026-01-01T00:00:00Z'))
+      .addColumn('status_changed_at', 'text')
+      .execute();
+
+    await db.schema.createTable('classes')
+      .addColumn('id', 'integer', c => c.primaryKey().autoIncrement())
+      .addColumn('event_id', 'integer', c => c.notNull())
+      .addColumn('class_id', 'text', c => c.notNull())
+      .addColumn('name', 'text', c => c.notNull())
+      .addColumn('long_title', 'text')
+      .execute();
+
+    await db.schema.createTable('participants')
+      .addColumn('id', 'integer', c => c.primaryKey().autoIncrement())
+      .addColumn('event_id', 'integer', c => c.notNull())
+      .addColumn('participant_id', 'text', c => c.notNull())
+      .addColumn('class_id', 'integer')
+      .addColumn('event_bib', 'integer')
+      .addColumn('athlete_id', 'text')
+      .addColumn('family_name', 'text', c => c.notNull())
+      .addColumn('given_name', 'text')
+      .addColumn('noc', 'text')
+      .addColumn('club', 'text')
+      .addColumn('cat_id', 'text')
+      .addColumn('is_team', 'integer', c => c.notNull().defaultTo(0))
+      .addColumn('member1', 'text')
+      .addColumn('member2', 'text')
+      .addColumn('member3', 'text')
+      .execute();
+
+    await db.schema.createTable('races')
+      .addColumn('id', 'integer', c => c.primaryKey().autoIncrement())
+      .addColumn('event_id', 'integer', c => c.notNull())
+      .addColumn('race_id', 'text', c => c.notNull())
+      .addColumn('class_id', 'integer')
+      .addColumn('race_type', 'text')
+      .addColumn('race_order', 'integer')
+      .addColumn('start_time', 'text')
+      .addColumn('start_interval', 'text')
+      .addColumn('course_nr', 'integer')
+      .addColumn('race_status', 'integer', c => c.notNull().defaultTo(0))
+      .execute();
+
+    await db.schema.createTable('courses')
+      .addColumn('id', 'integer', c => c.primaryKey().autoIncrement())
+      .addColumn('event_id', 'integer', c => c.notNull())
+      .addColumn('course_nr', 'integer', c => c.notNull())
+      .addColumn('nr_gates', 'integer')
+      .addColumn('gate_config', 'text')
+      .execute();
+
+    await db.schema.createTable('results')
+      .addColumn('id', 'integer', c => c.primaryKey().autoIncrement())
+      .addColumn('event_id', 'integer', c => c.notNull())
+      .addColumn('race_id', 'integer', c => c.notNull())
+      .addColumn('participant_id', 'integer', c => c.notNull())
+      .addColumn('start_order', 'integer')
+      .addColumn('bib', 'integer')
+      .addColumn('start_time', 'text')
+      .addColumn('status', 'text')
+      .addColumn('dt_start', 'text')
+      .addColumn('dt_finish', 'text')
+      .addColumn('time', 'integer')
+      .addColumn('gates', 'text')
+      .addColumn('pen', 'integer')
+      .addColumn('total', 'integer')
+      .addColumn('rnk', 'integer')
+      .addColumn('rnk_order', 'integer')
+      .addColumn('cat_rnk', 'integer')
+      .addColumn('cat_rnk_order', 'integer')
+      .addColumn('total_behind', 'text')
+      .addColumn('cat_total_behind', 'text')
+      .addColumn('prev_time', 'integer')
+      .addColumn('prev_pen', 'integer')
+      .addColumn('prev_total', 'integer')
+      .addColumn('prev_rnk', 'integer')
+      .addColumn('total_total', 'integer')
+      .addColumn('better_run_nr', 'integer')
+      .addColumn('heat_nr', 'integer')
+      .addColumn('round_nr', 'integer')
+      .addColumn('qualified', 'text')
+      .execute();
+
+    // Seed event, class, races, participants
+    const ev = await db.insertInto('events').values({
+      event_id: 'TEST.162', main_title: 'Test', status: 'running', has_xml_data: 1,
+    }).returning('id').executeTakeFirstOrThrow();
+    eventId = ev.id;
+
+    const cls = await db.insertInto('classes').values({
+      event_id: eventId, class_id: 'K1M_ST', name: 'K1 Men',
+    }).returning('id').executeTakeFirstOrThrow();
+
+    await db.insertInto('participants').values([
+      // BR1 DNF + BR2 clean
+      { event_id: eventId, participant_id: 'P1', class_id: cls.id, event_bib: 1, family_name: 'Alpha', given_name: 'A', club: 'X', cat_id: 'SEN' },
+      // BR1 clean + BR2 DNF
+      { event_id: eventId, participant_id: 'P2', class_id: cls.id, event_bib: 2, family_name: 'Beta', given_name: 'B', club: 'X', cat_id: 'SEN' },
+      // Both DNS (combined status expected)
+      { event_id: eventId, participant_id: 'P3', class_id: cls.id, event_bib: 3, family_name: 'Gamma', given_name: 'G', club: 'X', cat_id: 'SEN' },
+    ]).execute();
+
+    const br1 = await db.insertInto('races').values({
+      event_id: eventId, race_id: 'K1M_ST_BR1_6', class_id: cls.id, race_type: 'best-run-1', race_status: 5,
+    }).returning('id').executeTakeFirstOrThrow();
+    const br2 = await db.insertInto('races').values({
+      event_id: eventId, race_id: 'K1M_ST_BR2_6', class_id: cls.id, race_type: 'best-run-2', race_status: 3,
+    }).returning('id').executeTakeFirstOrThrow();
+
+    const [p1, p2, p3] = await db.selectFrom('participants').select('id').execute();
+
+    // P1: BR1 DNF, BR2 clean (9000)
+    await db.insertInto('results').values({
+      event_id: eventId, race_id: br1.id, participant_id: p1.id, bib: 1,
+      time: null, pen: 0, total: null, status: 'DNF', rnk: null,
+    }).execute();
+    await db.insertInto('results').values({
+      event_id: eventId, race_id: br2.id, participant_id: p1.id, bib: 1,
+      time: 8800, pen: 200, total: 9000, status: null, rnk: 1,
+    }).execute();
+
+    // P2: BR1 clean (10866), BR2 DNF
+    await db.insertInto('results').values({
+      event_id: eventId, race_id: br1.id, participant_id: p2.id, bib: 2,
+      time: 10466, pen: 4, total: 10866, status: null, rnk: 1,
+    }).execute();
+    await db.insertInto('results').values({
+      event_id: eventId, race_id: br2.id, participant_id: p2.id, bib: 2,
+      time: null, pen: 0, total: null, status: 'DNF', rnk: null,
+    }).execute();
+
+    // P3: both DNS
+    await db.insertInto('results').values({
+      event_id: eventId, race_id: br1.id, participant_id: p3.id, bib: 3,
+      time: null, pen: 0, total: null, status: 'DNS', rnk: null,
+    }).execute();
+    await db.insertInto('results').values({
+      event_id: eventId, race_id: br2.id, participant_id: p3.id, bib: 3,
+      time: null, pen: 0, total: null, status: 'DNS', rnk: null,
+    }).execute();
+
+    app = Fastify();
+    registerResultsRoutes(app, db);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.destroy();
+  });
+
+  it('BR1 DNF + BR2 clean → response carries prevStatus=DNF, currStatus=null', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/events/TEST.162/results/K1M_ST_BR2_6',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    const p1 = body.results.find((r: { bib: number }) => r.bib === 1);
+    expect(p1).toBeDefined();
+    // Combined `status` stays null so the row keeps its rank.
+    expect(p1.status).toBeNull();
+    // Per-run fields (the fix)
+    expect(p1.prevStatus).toBe('DNF');
+    expect(p1.currStatus).toBeNull();
+    // Primary fields = BR2 (the clean run) so ranking still works.
+    expect(p1.total).toBe(9000);
+    expect(p1.betterRunNr).toBe(2);
+    // prevTotal is still null (BR1 DNF had no total) — but the client now
+    // has prevStatus to disambiguate from "BR1 doesn't exist".
+    expect(p1.prevTotal).toBeNull();
+  });
+
+  it('BR1 clean + BR2 DNF → response carries prevStatus=null, currStatus=DNF', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/events/TEST.162/results/K1M_ST_BR2_6',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    const p2 = body.results.find((r: { bib: number }) => r.bib === 2);
+    expect(p2).toBeDefined();
+    expect(p2.status).toBeNull();
+    expect(p2.prevStatus).toBeNull();
+    expect(p2.currStatus).toBe('DNF');
+    expect(p2.prevTotal).toBe(10866);
+    expect(p2.betterRunNr).toBe(1);
+  });
+
+  it('both DNS → combined status set AND per-run fields populated', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/events/TEST.162/results/K1M_ST_BR2_6',
+    });
+
+    const body = JSON.parse(res.body);
+    const p3 = body.results.find((r: { bib: number }) => r.bib === 3);
+    expect(p3).toBeDefined();
+    expect(p3.status).toBe('DNS'); // infoSource (BR2) when no clean run
+    expect(p3.prevStatus).toBe('DNS');
+    expect(p3.currStatus).toBe('DNS');
+    expect(p3.betterRunNr).toBeNull();
+  });
+});

--- a/packages/server/tests/unit/BrCombinedService.test.ts
+++ b/packages/server/tests/unit/BrCombinedService.test.ts
@@ -144,7 +144,7 @@ describe('BrCombinedService', () => {
   }
 
   /** Seed BR1+BR2 results for a participant */
-  async function seedResults(pid: string, br1: { time: number; pen: number; total: number; rnk?: number; status?: string } | null, br2: { time: number; pen: number; total: number; rnk?: number; status?: string } | null) {
+  async function seedResults(pid: string, br1: { time: number | null; pen: number; total: number | null; rnk?: number; status?: string } | null, br2: { time: number | null; pen: number; total: number | null; rnk?: number; status?: string } | null) {
     const participantId = await getParticipantId(pid);
     const br1RaceId = await getRaceId('K1M_ST_BR1_6');
     const br2RaceId = await getRaceId('K1M_ST_BR2_6');
@@ -289,5 +289,92 @@ describe('BrCombinedService', () => {
     const viaBr2 = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
 
     expect(viaBr1).toEqual(viaBr2);
+  });
+
+  // Regression tests for #162 — per-run DNF/DNS visibility during live results.
+  // The combined `status` field alone cannot tell the client WHICH run was DNF/DNS
+  // when at least one clean run exists; we need `prevStatus` (BR1) and
+  // `currStatus` (BR2) so the client can render each run independently.
+  describe('#162 — per-run DNF/DNS status', () => {
+    it('exposes prevStatus when BR1 was DNF and BR2 is clean', async () => {
+      // BR1 DNF (no time/total), BR2 clean — the common case the user reported.
+      await seedResults('P1',
+        { time: null, pen: 0, total: null, status: 'DNF' },
+        { time: 8800, pen: 200, total: 9000 },
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      expect(results).toHaveLength(1);
+      // Combined status stays null (at least one clean run → rankable).
+      expect(results[0].status).toBeNull();
+      expect(results[0].betterRunNr).toBe(2);
+      expect(results[0].totalTotal).toBe(9000);
+      // Primary fields = BR2 (the clean run)
+      expect(results[0].time).toBe(8800);
+      expect(results[0].total).toBe(9000);
+      // Per-run status fields — the fix.
+      expect(results[0].prevStatus).toBe('DNF');
+      expect(results[0].currStatus).toBeNull();
+    });
+
+    it('exposes currStatus when BR1 is clean and BR2 was DNF', async () => {
+      // BR1 clean, BR2 DNF (e.g. bib 206 in xboardtest02_jarni_v1.xml).
+      await seedResults('P1',
+        { time: 10466, pen: 4, total: 10866, rnk: 3 },
+        { time: null, pen: 0, total: null, status: 'DNF' },
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      expect(results[0].status).toBeNull(); // combined: has clean run
+      expect(results[0].betterRunNr).toBe(1);
+      expect(results[0].totalTotal).toBe(10866);
+      // prevTotal carries BR1 clean time
+      expect(results[0].prevTotal).toBe(10866);
+      // Per-run status fields
+      expect(results[0].prevStatus).toBeNull();
+      expect(results[0].currStatus).toBe('DNF');
+    });
+
+    it('exposes both prevStatus and currStatus when both runs DNF/DSQ', async () => {
+      await seedResults('P1',
+        { time: null, pen: 0, total: null, status: 'DNF' },
+        { time: null, pen: 0, total: null, status: 'DSQ' },
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR1_6');
+
+      // Combined status reflects BR2 (infoSource) when no clean run exists.
+      expect(results[0].status).toBe('DSQ');
+      expect(results[0].betterRunNr).toBeNull();
+      expect(results[0].prevStatus).toBe('DNF');
+      expect(results[0].currStatus).toBe('DSQ');
+    });
+
+    it('exposes null prev fields when only BR1 exists (no BR2 row yet)', async () => {
+      // BR1 running, BR2 not yet created. Client uses prevStatus=null as
+      // "BR1 is the primary run, there is no BR2 yet".
+      await seedResults('P1', { time: 8300, pen: 200, total: 8500 }, null);
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR1_6');
+
+      expect(results[0].prevStatus).toBeNull();
+      expect(results[0].currStatus).toBeNull(); // BR1 clean, no status
+      expect(results[0].prevTotal).toBeNull();
+    });
+
+    it('exposes currStatus when only BR1 exists and was DNF', async () => {
+      // Purely BR1-only mode, DNF.
+      await seedResults('P1', { time: null, pen: 0, total: null, status: 'DNS' }, null);
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR1_6');
+
+      // infoSource is BR1 → combined status = 'DNS'
+      expect(results[0].status).toBe('DNS');
+      // currStatus mirrors "the run that occurred" — BR1 here.
+      expect(results[0].currStatus).toBe('DNS');
+      expect(results[0].prevStatus).toBeNull();
+    });
   });
 });

--- a/packages/shared/src/types/publicApi.ts
+++ b/packages/shared/src/types/publicApi.ts
@@ -245,6 +245,21 @@ export interface PublicResultMultiRun extends PublicResult {
   prevTotal: number | null;
   /** Other run rank */
   prevRnk: number | null;
+  /**
+   * Status of BR1 specifically (#162).
+   * `null` when BR1 was clean OR when BR1 does not yet exist.
+   * Unlike `status` (which is cleared when any run is clean so the
+   * participant remains rankable), this carries BR1's raw status so
+   * the client can render the Run 1 cell as a DNF/DNS badge even when
+   * BR2 is a clean run.
+   */
+  prevStatus: string | null;
+  /**
+   * Status of BR2 when both runs exist; mirrors BR1's status when only
+   * BR1 has been run. Companion to `prevStatus` for rendering the
+   * Run 2 cell independently (#162).
+   */
+  currStatus: string | null;
   /** Other run start timestamp */
   prevDtStart: string | null;
   /** Other run finish timestamp */


### PR DESCRIPTION
## Summary

- Fixes #162: during live BR races, DNF/DNS on one run showed wrong data (time labelled as the other run, or `-`) because the combined `status` field is cleared to null as soon as any run is clean.
- Server now exposes per-run status (`prevStatus` / `currStatus`) so the client can render Run 1 / Run 2 cells independently; client BR rendering uses these.

## Root cause

`BrCombinedService.computeCombined()` nulls the combined `status` when any run succeeds so the row stays rankable. Client then couldn't tell "BR1 DNF + BR2 clean" from "only BR2 exists", because `prevTotal` is null in both cases (BR1 DNF has no total). Run 1 cell fell back to `row.total` which is BR2's time; Run 2 cell fell back to `-`. Symmetric bug for BR1 clean + BR2 DNF — Run 2 lost its DNF badge.

## Fix

- `packages/server/src/services/BrCombinedService.ts` — add `prevStatus` (BR1) and `currStatus` (BR2, or BR1 when only BR1) to `CombinedBrResult`.
- `packages/server/src/routes/{results,ingest}.ts` + `schemas/index.ts` — propagate fields through REST, WS, schema.
- `packages/shared/src/types/publicApi.ts` — document on `PublicResultMultiRun`.
- `packages/client/src/services/api.ts` — extend `ResultEntry`.
- `packages/client/src/components/ResultList.tsx` — both desktop BR columns and mobile `BrRunsCell` use `hasBr1 = prevTotal != null || prevStatus != null` and render per-run badges from the new fields.

Backward-compatible: old clients receiving the extra fields just ignore them.

## Verification matrix

| BR1 | BR2 | Row rank | Run 1 cell | Run 2 cell |
|---|---|---|---|---|
| clean | clean | yes | BR1 time | BR2 time |
| DNF | clean | yes | **DNF badge** | BR2 time |
| clean | DNF | yes | BR1 time | **DNF badge** |
| DNS | DNS | no | DNS badge | DNS badge |
| clean | — | yes | BR1 time | `-` |
| DNF | — | no | DNF badge | `-` |

Rows 2–3 are the ones that were broken before this PR.

## Test plan

- [x] `npm run test --workspaces` — 211 tests pass (8 new: 5 unit + 3 integration + 4 client component)
- [x] `npm run build` — green (server tsc, client tsc -b + vite build)
- [x] Unit: `BrCombinedService.test.ts` — new `#162` describe block covers every BR1×BR2 DNF/DNS/clean/absent combo
- [x] Integration: `br-per-run-status.test.ts` — HTTP round-trip through the results endpoint, verifies Fastify schema accepts new fields
- [x] Component: `ResultList.br-status.test.tsx` — renders DNF badge in the correct cell for each scenario
- [ ] Manual: smoke-test on `staging` once deployed (push-to-staging + reload known DNF/DNS rows live)

## Related issues noticed

Not in scope for this PR, but flagging:
- `BrCombinedService` has a pre-existing hypothetical bug when only BR2 exists (no BR1 row): `time: hasBothRuns ? br2.time : br1?.time` returns null even though `br2.time` exists. In practice BR1 always gets created first in C123, so this likely never fires, but worth a cleanup ticket.

Closes #162