### PR TITLE
fix(client): trigger class tabs standalone row at 4+ categories

### DIFF
--- a/packages/client/src/pages/EventDetailPage.tsx
+++ b/packages/client/src/pages/EventDetailPage.tsx
@@ -758,10 +758,12 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
   const selectedRace = races.find((r) => r.raceId === selectedRaceId);
   const selectedRaceClassId = selectedRace?.classId ?? null;
   const showClassTabs = filteredClassGroups.length > 1;
-  const classTabsStandalone = filteredClassGroups.reduce(
-    (sum, g) => sum + (classNameMap[g.classId] ?? g.classId).length,
-    0
-  ) > 21;
+  const classTabsStandalone =
+    filteredClassGroups.length > 3 ||
+    filteredClassGroups.reduce(
+      (sum, g) => sum + (classNameMap[g.classId] ?? g.classId).length,
+      0
+    ) > 12;
   const displayRaces = selectedGroup?.displayRaces ?? [];
   const showRoundTabs = displayRaces.length > 1;
   const hasMergedBR = selectedGroup


### PR DESCRIPTION
## Summary

- Lowers the threshold for class tabs going to their own full-width row
- Previous rule (chars > 21) never triggered for typical 3-char class IDs (K1M, C1Ž, etc.)
- 5 categories × 3 chars = 15 — well under the old threshold, causing K1Ž to wrap inside the shared header row
- New rule: standalone when **4+ groups** OR **total display chars > 12**

## Reproduces

ww-cb.cz live site with Jarní slalomy 2026 (K1M, C1Ž, PZK, C1M, K1Ž) — K1Ž wrapped to second row.

## Test plan

- [ ] 5 categories (K1M, C1Ž, PZK, C1M, K1Ž) → all on own full-width row, no wrapping
- [ ] 2–3 categories → still inline with day tabs and view mode (no regression)
- [ ] 4 categories → standalone row triggered

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)