### PR TITLE
feat(client): favorites filter toggle in startlist

### DIFF
--- a/packages/client/src/pages/EventDetailPage.module.css
+++ b/packages/client/src/pages/EventDetailPage.module.css
@@ -56,8 +56,18 @@
   }
 }
 
+/* Toolbar row above startlist: search input + favorites toggle */
+.startlistToolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 /* Standalone search for startlist view */
 .startlistSearch {
+  flex: 1;
+  min-width: 8rem;
   max-width: 20rem;
 }
 

--- a/packages/client/src/pages/EventDetailPage.tsx
+++ b/packages/client/src/pages/EventDetailPage.tsx
@@ -29,6 +29,7 @@ import { ClassTabs } from '../components/ClassTabs';
 import { DataViewSelector } from '../components/DataViewSelector';
 import { ResultList } from '../components/ResultList';
 import { StartlistTable } from '../components/StartlistTable';
+import { FavoritesToggle } from '../components/FavoritesToggle';
 import { OnCoursePanel } from '../components/OnCoursePanel';
 import { ScheduleView } from '../components/ScheduleView';
 import type { ViewMode } from '../components/ViewModeToggle';
@@ -874,14 +875,21 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
       )}
 
       {resultsState === 'success' && dataView === 'startlist' && (
-        <div className={styles.startlistSearch}>
-          <SearchInput
-            key={`startlist|${selectedClassId ?? ''}|${selectedCatId ?? ''}`}
-            size="sm"
-            placeholder="Hledat závodníka..."
-            onChange={setSearchQuery}
-            debounceMs={200}
-            resultsCount={searchResultsCount}
+        <div className={styles.startlistToolbar}>
+          <div className={styles.startlistSearch}>
+            <SearchInput
+              key={`startlist|${selectedClassId ?? ''}|${selectedCatId ?? ''}`}
+              size="sm"
+              placeholder="Hledat závodníka..."
+              onChange={setSearchQuery}
+              debounceMs={200}
+              resultsCount={searchResultsCount}
+            />
+          </div>
+          <FavoritesToggle
+            active={favorites.showOnlyFavorites}
+            count={favorites.favoritesCount}
+            onToggle={() => favorites.setShowOnlyFavorites(!favorites.showOnlyFavorites)}
           />
         </div>
       )}
@@ -895,7 +903,16 @@ export function EventDetailPage({ eventId, raceId: urlRaceId }: EventDetailPageP
         />
       )}
 
-      {resultsState === 'success' && dataView === 'startlist' && (!filteredStartlist || filteredStartlist.length === 0) && (
+      {resultsState === 'success' && dataView === 'startlist' && startlist && startlist.length > 0 && (!filteredStartlist || filteredStartlist.length === 0) && (
+        <Card>
+          <EmptyState
+            title={favorites.showOnlyFavorites ? 'Žádní oblíbení v této startovce' : 'Žádný závodník neodpovídá hledání'}
+            description="Zkuste upravit filtry nebo hledání."
+          />
+        </Card>
+      )}
+
+      {resultsState === 'success' && dataView === 'startlist' && (!startlist || startlist.length === 0) && (
         <Card>
           <EmptyState
             title="Startovní listina není k dispozici"


### PR DESCRIPTION
## Summary

Brings the same star-filter UX already present in results into the **startlist** view — a compact ★ toggle button that, when active, shows only athletes the user has starred.

- The filtering logic (`filteredStartlist` in `EventDetailPage`) was already in place and listening to `favorites.showOnlyFavorites`. Only the UI control was missing.
- Adds `FavoritesToggle` next to the search input in the startlist toolbar. The button auto-hides when no favorites exist and the filter is off (existing behavior).
- Splits the "empty startlist" `<Card>` into two cases: (a) startlist truly not published → *"Startovní listina není k dispozici"*; (b) startlist has entries but filter/search narrowed to zero → *"Žádní oblíbení v této startovce"* / *"Žádný závodník neodpovídá hledání"*. Previously case (b) misleadingly showed "not available".

Closes #152

## Test plan

- [x] `npm test` — 226 pass / 2 skipped, no regressions
- [x] `npm run typecheck` (client) — clean
- [x] `npm run build` — clean
- [ ] Staging smoke test: star an athlete in a class with a populated startlist, open the startovka tab, toggle ★ button — only starred athletes remain; click again — full list returns
- [ ] Mobile viewport: toolbar wraps cleanly, toggle remains tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)