### PR TITLE
fix(server): sanitise C123 TCP best-run pollution in BR2 results

### DIFF
--- a/packages/server/src/services/BrCombinedService.ts
+++ b/packages/server/src/services/BrCombinedService.ts
@@ -92,13 +92,52 @@ export class BrCombinedService {
       if (catId && firstRun.cat_id !== catId) continue;
 
       const br1 = runs.find((r) => r.race_type === 'best-run-1');
-      const br2 = runs.find((r) => r.race_type === 'best-run-2');
+      const br2Raw = runs.find((r) => r.race_type === 'best-run-2');
 
-      // Calculate totalTotal and betterRunNr
+      // #180: Detect C123 TCP "best-run" pollution. When BR1 was the better
+      // run, the BR2 Results frame from Canoe123 carries BR1's pen/total in
+      // the BR2 row's pen/total fields (verified empirically against a 30 min
+      // recording chunk: 1142/1142 inconsistent rows had br2.pen exactly
+      // equal to br1.pen). c123-server mitigates this with an OnCourse
+      // penalty cache (10 s TTL) and an XML fallback; when both miss, the
+      // corruption arrives here.
+      //
+      // Pattern: br2 row not self-consistent (total ≠ time + pen) AND
+      // br2.total ≈ br1.total (BR1's "best total" leaked into the BR2 row).
+      // The 2 cs tolerance absorbs C123's internal rounding noise.
+      const br2IsPolluted =
+        br1 != null &&
+        br2Raw != null &&
+        !br1.status &&
+        !br2Raw.status &&
+        br1.total != null &&
+        br2Raw.time != null &&
+        br2Raw.pen != null &&
+        br2Raw.total != null &&
+        Math.abs(br2Raw.total - (br2Raw.time + br2Raw.pen)) > 2 &&
+        Math.abs(br2Raw.total - br1.total) <= 2;
+
+      // For display, distrust BR2's pen and rebase total to br2.time.
+      // Naively recomputing total = time + pen would Frankenstein BR2's actual
+      // time with BR1's penalty (e.g. competitor ran a missed gate but UI
+      // reports a clean run). Reporting just the time is honest about
+      // unknown pen and never wrong about the BR2 finishing time.
+      const br2 = br2IsPolluted
+        ? { ...br2Raw, pen: null, total: br2Raw.time }
+        : br2Raw;
+
+      // Calculate totalTotal and betterRunNr.
+      // When pollution is detected we already KNOW BR1 was the better run
+      // (br1.total is what BR2's frame had carried as its "best total").
+      // Short-circuit ranking so a sanitised br2.total = br2.time can't
+      // accidentally beat br1.total when BR2's actual penalty was large.
       let totalTotal: number | null = null;
       let betterRunNr: number | null = null;
 
-      if (br1?.total != null && br2?.total != null && !br1.status && !br2.status) {
+      if (br2IsPolluted) {
+        totalTotal = br1!.total;
+        betterRunNr = 1;
+      } else if (br1?.total != null && br2?.total != null && !br1.status && !br2.status) {
         // Both runs completed successfully
         if (br1.total <= br2.total) {
           totalTotal = br1.total;

--- a/packages/server/tests/unit/BrCombinedService.test.ts
+++ b/packages/server/tests/unit/BrCombinedService.test.ts
@@ -399,4 +399,125 @@ describe('BrCombinedService', () => {
       expect(results[0].prevStatus).toBeNull();
     });
   });
+
+  // Regression tests for #180 — C123 TCP "best-run" pollution in BR2 results.
+  // C123's BR2 Results frame ships best-of-both-runs in `pen`/`total` when
+  // BR1 was the better run. c123-server mitigates via an OnCourse penalty
+  // cache (10 s TTL); when that cache misses, corruption flows through to
+  // live-mini. Verified empirically against a 30-min recording chunk:
+  // 1142/1142 inconsistent rows where BR1 was better had `pen` exactly equal
+  // to BR1's pen (Frankenstein recompute `time + pen` would lie).
+  //
+  // Detection pattern: br2 row not self-consistent (total ≠ time + pen) AND
+  // br2.total ≈ br1.total (= BR1's "best total" leaked into BR2's row).
+  describe('#180 — C123 TCP best-run pollution sanitisation', () => {
+    it('sanitises BR2 row when total looks like BR1 best-run pollution', async () => {
+      // Real shape from recording (bib 14 of K1M_BR2_18, scaled to centiseconds):
+      //   BR1 final:  time=9332, pen=2, total=9334 (one touch on a clean run)
+      //   BR2 actual: had a missed gate (+50s pen) — not visible in TCP frame
+      //   TCP BR2:    time=9344 (BR2 real time), pen=2 (BR1's), total=9334 (BR1's)
+      // Without sanitisation the Run 2 cell shows 9334 cs (BR1's better total).
+      await seedResults('P1',
+        { time: 9332, pen: 2, total: 9334, rnk: 1 },
+        { time: 9344, pen: 2, total: 9334 },
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      expect(results).toHaveLength(1);
+      // Top-level fields come from the (sanitised) BR2 primary slot.
+      expect(results[0].time).toBe(9344);          // BR2 actual time, preserved
+      expect(results[0].pen).toBeNull();           // pen distrusted (would lie)
+      expect(results[0].total).toBe(9344);         // total = time → no Frankenstein
+      // Combined ranking still picks BR1 as the better run.
+      expect(results[0].betterRunNr).toBe(1);
+      expect(results[0].totalTotal).toBe(9334);
+      // BR1's clean values flow through unchanged in prev*.
+      expect(results[0].prevTime).toBe(9332);
+      expect(results[0].prevPen).toBe(2);
+      expect(results[0].prevTotal).toBe(9334);
+    });
+
+    it('passes consistent BR2 (BR2 was better) through unchanged', async () => {
+      // No pollution: total = time + pen exactly, BR2 better than BR1.
+      await seedResults('P1',
+        { time: 9000, pen: 200, total: 9200 },
+        { time: 8500, pen: 200, total: 8700 },
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      // pen/total preserved — sanitisation must not fire.
+      expect(results[0].time).toBe(8500);
+      expect(results[0].pen).toBe(200);
+      expect(results[0].total).toBe(8700);
+      expect(results[0].betterRunNr).toBe(2);
+      expect(results[0].totalTotal).toBe(8700);
+    });
+
+    it('does not sanitise when BR2 is inconsistent but not BR1-pollution', async () => {
+      // BR2 row not self-consistent, but total also doesn't match BR1's total —
+      // some unrelated anomaly. Be conservative: pass through unchanged so we
+      // don't quietly mangle data we don't understand.
+      await seedResults('P1',
+        { time: 8000, pen: 100, total: 8100 },
+        { time: 8500, pen: 200, total: 8800 }, // 8800 ≠ 8500+200=8700 AND 8800 ≠ 8100
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      expect(results[0].pen).toBe(200);
+      expect(results[0].total).toBe(8800);
+    });
+
+    it('tolerates 2 cs floating-point jitter without false-positive', async () => {
+      // 1-2 cs gap between time+pen and total can occur from C123's internal
+      // rounding. Threshold is "> 2", so this stays in the consistent branch.
+      await seedResults('P1',
+        { time: 9000, pen: 200, total: 9200 },
+        { time: 8500, pen: 200, total: 8702 }, // 2 cs noise
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      expect(results[0].pen).toBe(200);
+      expect(results[0].total).toBe(8702);
+    });
+
+    it('does not sanitise BR2 status rows (DSQ keeps existing #162 behaviour)', async () => {
+      // DSQ rows have null time/pen/total. Pollution check requires all three
+      // non-null and !status, so it never fires here — sentinel guard.
+      await seedResults('P1',
+        { time: 8300, pen: 200, total: 8500 },
+        { time: null, pen: 0, total: null, status: 'DSQ' },
+      );
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      expect(results[0].currStatus).toBe('DSQ');
+      expect(results[0].betterRunNr).toBe(1);
+      expect(results[0].totalTotal).toBe(8500);
+    });
+
+    it('forces betterRunNr=1 even when polluted br2.time would falsely beat br1', async () => {
+      // Subtle ranking trap: BR1 had a slow time + small pen; BR2's actual
+      // time was faster but BR2 had a huge penalty (so BR2 actually slower).
+      // TCP ships BR2 with BR1's pen/total. Sanitising naively (total = time)
+      // and then comparing br1.total vs br2.time would mark BR2 as better
+      // even though it wasn't. The fix must short-circuit ranking on detected
+      // pollution.
+      await seedResults('P1',
+        { time: 8000, pen: 500, total: 8500, rnk: 1 },     // BR1 actual: 80.00 + 5.00 pen = 85.00
+        { time: 7800, pen: 500, total: 8500 },             // TCP frame: t=78.00 (real), pen+total=BR1's
+      );
+      // Real BR2 had ~9 s of penalty making BR2 actual = 87.x — slower than BR1.
+      // But br2.time (78.00) < br1.total (85.00), so naive ranking picks BR2.
+
+      const results = await service.computeCombined(eventId, 'K1M_ST_BR2_6');
+
+      // Pollution detected → BR1 stays the better run.
+      expect(results[0].betterRunNr).toBe(1);
+      expect(results[0].totalTotal).toBe(8500);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the alternation reported in #180 where the **Run 2** cell in BR results occasionally shows BR1's better total instead of BR2's actual run, when BR1 was the faster run.

## Root cause (verified empirically)

C123's BR2 Results frame ships **best-of-both-runs** values in `pen` and `total` when BR1 was better:
- `time` field = BR2 actual time ✅
- `pen` / `total` fields = BR1's values, mislabeled as BR2's ❌

`c123-server/LiveTransformer.ts` already mitigates this with an OnCourse penalty cache (10 s TTL) and an XML fallback. When both miss, the fallback (`LiveTransformer.ts:209-219`) ships the corrupted frame straight to live-mini, where it's stored in the BR2 row and broadcast unchanged via `BrCombinedService`. The client `resolveBrRuns` routes `row.total` into the Run 2 cell, so the user sees BR1's better total. The "alternation" is the cache hit/miss cycle.

**Verification against a real recording** (Saturday afternoon, 30 min chunk):

| Metric | Count |
|---|---:|
| Inconsistent BR2 rows (BR1 was better) | **1 253** |
| Of those with a matched BR1 final | 1 142 |
| `TCP_BR2.pen == BR1.pen` | **1 142 / 1 142 (100 %)** |
| `TCP_BR2.pen` differs from BR1.pen | 0 |

So `pen` in the BR2 frame is **always** BR1's pen, never BR2's actual. A naive `total = time + pen` recompute (the "scoreboard model") would Frankenstein BR2's time with BR1's penalty — e.g. bib 3 from the recording would show "Run 2: 75.42 (clean)" while the athlete actually missed a gate (+50 s).

## Fix

Server-only, scoped to `BrCombinedService.computeCombined()`. No DB schema change, no client change, no c123-server change.

Detection (Gemini's two-step pattern):
1. **Self-inconsistency:** `|br2.total - (br2.time + br2.pen)| > 2 cs`
2. **Best-run pollution:** `|br2.total - br1.total| <= 2 cs` (i.e. BR2's `total` is BR1's leaked best total)

Both must hold. The 2 cs tolerance absorbs C123's internal rounding noise; real pollution gaps are hundreds of cs.

When detected, sanitise `br2`:
- `pen = null` — distrust it; we don't know BR2's actual penalty
- `total = br2.time` — honest about the BR2 finishing time, no Frankenstein
- Combined ranking short-circuits to `(totalTotal = br1.total, betterRunNr = 1)` since pollution detection already proves BR1 was the better run. This also prevents a sanitised `br2.total = br2.time` from accidentally beating `br1.total` when BR2's actual penalty was large.

DSQ/DNF rows have null `time`/`pen`/`total`, so the check never fires — existing #162 behaviour is preserved.

## Test plan

Unit tests in `BrCombinedService.test.ts` (`#180` describe block, 6 cases):
- ✅ Sanitises BR2 row when total looks like BR1 best-run pollution (modelled on real `bib=14` row from the recording)
- ✅ Passes consistent BR2 (BR2 was better) through unchanged
- ✅ Does not sanitise when BR2 is inconsistent but `total` doesn't match BR1's (be conservative — only the well-defined pollution shape triggers)
- ✅ Tolerates 2 cs floating-point jitter without false-positive
- ✅ DSQ/DNF status rows bypass the check (preserves #162)
- ✅ Forces `betterRunNr=1` even when polluted `br2.time` would falsely beat `br1.total` (catches the ranking trap a naive sanitiser would introduce)

```
$ npm --workspace @c123-live-mini/server test
Test Files  11 passed (11)
Tests  138 passed | 2 skipped (140)

$ cd packages/server && npx tsc --noEmit
(clean)

$ npm --workspace @c123-live-mini/client test
Test Files  11 passed (11)
Tests  97 passed (97)
```

- [ ] Manual smoke on staging after deploy. Staging's data is XML-imported (no corruption), so the main check is "no regressions on existing BR display"; pollution path can only be reproduced with a TCP replay.

## Out of scope (separate tickets)

- The `Gates` field in the BR2 frame is BR2's actual gate-by-gate penalty (verified against the recording — `sum(gates)` in CS matches BR2 actual pen). It could replace `pen=null` with a more useful value, but c123-server doesn't currently forward gate-level data on the results ingest path. Worth its own ticket.
- c123-server's OnCourse cache TTL extension or persistent BR2 pen learning. Local rollout to venues is harder than a live-mini deploy.

Closes #180