### PR TITLE
chore: align release-please manifest after drift

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   ".": "0.12.1",
-  "packages/client": "0.12.0",
-  "packages/server": "0.10.1",
-  "packages/shared": "0.10.0"
+  "packages/client": "0.12.1",
+  "packages/server": "0.12.1",
+  "packages/shared": "0.12.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5586,7 +5586,7 @@
     },
     "packages/client": {
       "name": "@c123-live-mini/client",
-      "version": "0.9.1",
+      "version": "0.12.1",
       "dependencies": {
         "@c123-live-mini/shared": "*",
         "@czechcanoe/rvp-design-system": "latest",
@@ -5609,7 +5609,7 @@
     },
     "packages/server": {
       "name": "@c123-live-mini/server",
-      "version": "0.9.1",
+      "version": "0.12.1",
       "dependencies": {
         "@c123-live-mini/shared": "*",
         "@fastify/static": "^8.3.0",
@@ -5630,7 +5630,7 @@
     },
     "packages/shared": {
       "name": "@c123-live-mini/shared",
-      "version": "0.9.1",
+      "version": "0.12.1",
       "devDependencies": {
         "typescript": "^5.7.3"
       }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c123-live-mini/client",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.10.1](https://github.com/OpenCanoeTiming/c123-live-mini/compare/v0.10.0...v0.10.1) (2026-04-29)
+## [0.12.1](https://github.com/OpenCanoeTiming/c123-live-mini/compare/v0.12.0...v0.12.1) (2026-04-29)
 
 
 ### Bug Fixes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c123-live-mini/server",
-  "version": "0.10.1",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c123-live-mini/shared",
-  "version": "0.10.0",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Realigns `.release-please-manifest.json` and per-package `package.json` versions after manifest drift caused the v0.12.1 release workflow to fail.

## Background

After PR #183 (`chore: release main`) merged, the `release-please.yml` workflow run (`25101445445`) failed with `Validation Failed: tag_name already_exists` for `v0.10.1`. Root cause: the manifest had drifted across packages:

```
.: 0.12.1                ← root, just bumped
packages/client: 0.12.0  ← drift
packages/server: 0.10.1  ← drift, tag already existed
packages/shared: 0.10.0  ← drift, tag already existed
```

Combined with `include-component-in-tag: false` + the `linked-versions` plugin, Release Please tried to create the global `v0.X.Y` tag using mismatched per-package versions. It hit existing tags from prior cycles → 422 Conflict → workflow exited before creating any new tag/release.

The intended `v0.12.1` tag and GitHub Release were created manually at release commit `6654649` post-failure, so the release itself exists.

## Changes

- `.release-please-manifest.json`: client/server/shared all → `0.12.1`
- `packages/{client,server,shared}/package.json`: version → `0.12.1`
- `packages/server/CHANGELOG.md`: fix the new entry header from `0.10.1` to `0.12.1` (matches the actual tag)
- `package-lock.json`: regenerated via `npm install` (had even older `0.9.1` lockfile entries)

## Why `chore:`

Avoids triggering a new release-please version bump. Future feat/fix commits will bump from a consistent `0.12.1` baseline.

## Test plan

- [x] `npm install` clean
- [x] No code changes — just metadata
- [ ] CI green
- [ ] Post-merge: deploy to staging + production for SHA alignment (no behavioural change)