### PR TITLE
chore: collapse release-please to single-package monorepo config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,3 @@
 {
-  ".": "0.12.2",
-  "packages/client": "0.12.2",
-  "packages/server": "0.12.1",
-  "packages/shared": "0.12.1"
+  ".": "0.12.2"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,10 +161,10 @@ This project uses **Release Please** (commit-based) for automatic versioning of 
 
 1. Every push to `main` runs `.github/workflows/release-please.yml`.
 2. Release Please keeps a rolling **release PR** open (label `autorelease: pending`) that aggregates pending changes and proposes the next version.
-3. The `linked-versions` plugin keeps all four packages on the **same version**: root `c123-live-mini`, `@c123-live-mini/client`, `@c123-live-mini/server`, `@c123-live-mini/shared`.
+3. release-please tracks **only the root** `c123-live-mini` package. The three workspace `package.json` files (`packages/client`, `packages/server`, `packages/shared`) and their `package-lock.json` workspace entries are bumped via `extra-files`, so all four stay on the **same version** automatically. There is one root `CHANGELOG.md` for the whole repo (per-package CHANGELOG files in `packages/*/` are frozen historical records from the pre-2026-04-29 multi-package config — not updated anymore).
 4. Merging the release PR creates:
-   - A commit `chore(main): release X.Y.Z` on `main` that bumps all four `package.json` files
-   - A single git tag `vX.Y.Z` (shared, no per-package tag because `include-component-in-tag: false`)
+   - A commit `chore(main): release X.Y.Z` on `main` that bumps all four `package.json` files plus the matching `package-lock.json` entries
+   - A single git tag `vX.Y.Z` (no per-package tag because `include-component-in-tag: false`)
    - A GitHub Release with generated CHANGELOG
 5. Railway auto-deploys `main` → staging. Promoting `main` → `production` is a separate manual fast-forward.
 6. `SHARED_VERSION` (shown in the client footer) reads dynamically from `packages/shared/package.json`, so it stays in sync automatically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5586,7 +5586,7 @@
     },
     "packages/client": {
       "name": "@c123-live-mini/client",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "@c123-live-mini/shared": "*",
         "@czechcanoe/rvp-design-system": "latest",
@@ -5609,7 +5609,7 @@
     },
     "packages/server": {
       "name": "@c123-live-mini/server",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "@c123-live-mini/shared": "*",
         "@fastify/static": "^8.3.0",
@@ -5630,7 +5630,7 @@
     },
     "packages/shared": {
       "name": "@c123-live-mini/shared",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "devDependencies": {
         "typescript": "^5.7.3"
       }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c123-live-mini/server",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c123-live-mini/shared",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,28 +18,16 @@
     { "type": "ci", "section": "Continuous Integration", "hidden": true }
   ],
   "packages": {
-    "packages/client": {
-      "package-name": "@c123-live-mini/client",
-      "component": "client"
-    },
-    "packages/server": {
-      "package-name": "@c123-live-mini/server",
-      "component": "server"
-    },
-    "packages/shared": {
-      "package-name": "@c123-live-mini/shared",
-      "component": "shared"
-    },
     ".": {
       "package-name": "c123-live-mini",
-      "component": "root"
+      "extra-files": [
+        "packages/client/package.json",
+        "packages/server/package.json",
+        "packages/shared/package.json",
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/client'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/server'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/shared'].version" }
+      ]
     }
-  },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "c123-live-mini",
-      "components": ["client", "server", "shared", "root"]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Problem

`linked-versions` plugin only operates on packages that have a candidate release for the cycle — i.e., packages with conventional commits scoped to that package since the last tag. Packages with no scoped commits silently stay at their old version, producing drift on every release:

| Release | What got bumped | What got left behind |
|---|---|---|
| 0.12.1 (#183) | root + server (server-scoped fix) | client + shared stayed at older versions → manual sync via #184 |
| 0.12.2 (#186) | root + client (client-scoped fix #182) | server + shared stayed at 0.12.1 |

The drift is structural — each scoped fix release reproduces it. The `package-lock.json` workspace entries also drift because release-please only updates the lockfile entry of the tracked package.

## Approach

Single-package release-please config that tracks **only the root** `c123-live-mini` and bumps the workspace package.json files (plus their entries in `package-lock.json`) via `extra-files`. One CHANGELOG.md at root. No more `linked-versions` plugin.

This monorepo only ships internally — there is no consumer of `@c123-live-mini/{client,server,shared}` outside the repo. Per-package versioning + per-package CHANGELOGs were adding cost (manual sync intervals, drift between footer and actual release tag) without value.

## What changes

- `release-please-config.json`: collapsed from 4 packages + linked-versions plugin to 1 package (`.`) with `extra-files` for workspace `package.json` and `package-lock.json` JSONPath entries.
- `.release-please-manifest.json`: only `.` entry now.
- `packages/server/package.json` and `packages/shared/package.json`: bumped from 0.12.1 → 0.12.2 to align with current release tag (the actual drift cleanup).
- `package-lock.json`: workspace entries synced to 0.12.2.
- `CLAUDE.md`: documentation updated to reflect the single-source-of-truth model.

## What stays

- `vX.Y.Z` tag format (no per-package tags — already disabled with `include-component-in-tag: false`).
- `bump-minor-pre-major: true` (0.x series rules unchanged).
- `changelog-sections` config (CHANGELOG section structure unchanged).
- Conventional commit semantics: `feat(client):` still produces a minor bump in CHANGELOG section "Features" — scope is now decorative for changelog readability, doesn't gate which packages bump.
- Per-package `packages/*/CHANGELOG.md` files — left as frozen historical record from the multi-package era.

## Verification

`npx release-please release-pr --target-branch=<this branch with a temp fix commit on top> --dry-run` produces a single proposed release PR titled `release 0.12.3` whose update list contains:

```
package.json                              [PackageJson]
packages/client/package.json              [CompositeUpdater]
packages/server/package.json              [CompositeUpdater]
packages/shared/package.json              [CompositeUpdater]
package-lock.json                         [CompositeUpdater]   ← root + 3 workspace entries via JSONPath
CHANGELOG.md                              [Changelog]
.release-please-manifest.json             [ReleasePleaseManifest]
```

All four package.json files would bump together. No drift.

## Migration cleanliness

This is a `chore:` commit so it does not itself trigger a release-please bump. After merge the rolling release PR would simply read the new config; nothing to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)