### PR TITLE
fix(server): prune stale records on XML re-ingest

### DIFF
--- a/packages/server/src/db/repositories/ClassRepository.ts
+++ b/packages/server/src/db/repositories/ClassRepository.ts
@@ -150,6 +150,21 @@ export class ClassRepository extends BaseRepository {
     return Number(result.numDeletedRows);
   }
 
+  async deleteByEventIdNotIn(
+    eventId: number,
+    keepClassIds: string[]
+  ): Promise<number> {
+    if (keepClassIds.length === 0) {
+      return this.deleteByEventId(eventId);
+    }
+    const result = await this.db
+      .deleteFrom('classes')
+      .where('event_id', '=', eventId)
+      .where('class_id', 'not in', keepClassIds)
+      .executeTakeFirst();
+    return Number(result.numDeletedRows);
+  }
+
   // Category methods
 
   /**

--- a/packages/server/src/db/repositories/CourseRepository.ts
+++ b/packages/server/src/db/repositories/CourseRepository.ts
@@ -116,6 +116,21 @@ export class CourseRepository extends BaseRepository {
     return Number(result.numDeletedRows);
   }
 
+  async deleteByEventIdNotIn(
+    eventId: number,
+    keepCourseNrs: number[]
+  ): Promise<number> {
+    if (keepCourseNrs.length === 0) {
+      return this.deleteByEventId(eventId);
+    }
+    const result = await this.db
+      .deleteFrom('courses')
+      .where('event_id', '=', eventId)
+      .where('course_nr', 'not in', keepCourseNrs)
+      .executeTakeFirst();
+    return Number(result.numDeletedRows);
+  }
+
   /**
    * Count courses by event
    */

--- a/packages/server/src/db/repositories/ParticipantRepository.ts
+++ b/packages/server/src/db/repositories/ParticipantRepository.ts
@@ -156,6 +156,21 @@ export class ParticipantRepository extends BaseRepository {
     return Number(result.numDeletedRows);
   }
 
+  async deleteByEventIdNotIn(
+    eventId: number,
+    keepParticipantIds: string[]
+  ): Promise<number> {
+    if (keepParticipantIds.length === 0) {
+      return this.deleteByEventId(eventId);
+    }
+    const result = await this.db
+      .deleteFrom('participants')
+      .where('event_id', '=', eventId)
+      .where('participant_id', 'not in', keepParticipantIds)
+      .executeTakeFirst();
+    return Number(result.numDeletedRows);
+  }
+
   /**
    * Count participants by event
    */

--- a/packages/server/src/db/repositories/RaceRepository.ts
+++ b/packages/server/src/db/repositories/RaceRepository.ts
@@ -144,6 +144,21 @@ export class RaceRepository extends BaseRepository {
     return Number(result.numDeletedRows);
   }
 
+  async deleteByEventIdNotIn(
+    eventId: number,
+    keepRaceIds: string[]
+  ): Promise<number> {
+    if (keepRaceIds.length === 0) {
+      return this.deleteByEventId(eventId);
+    }
+    const result = await this.db
+      .deleteFrom('races')
+      .where('event_id', '=', eventId)
+      .where('race_id', 'not in', keepRaceIds)
+      .executeTakeFirst();
+    return Number(result.numDeletedRows);
+  }
+
   /**
    * Update race status
    */

--- a/packages/server/src/db/repositories/ResultRepository.ts
+++ b/packages/server/src/db/repositories/ResultRepository.ts
@@ -160,6 +160,21 @@ export class ResultRepository extends BaseRepository {
     return Number(result.numDeletedRows);
   }
 
+  async deleteByRaceIdNotInParticipants(
+    raceId: number,
+    keepParticipantDbIds: number[]
+  ): Promise<number> {
+    if (keepParticipantDbIds.length === 0) {
+      return this.deleteByRaceId(raceId);
+    }
+    const result = await this.db
+      .deleteFrom('results')
+      .where('race_id', '=', raceId)
+      .where('participant_id', 'not in', keepParticipantDbIds)
+      .executeTakeFirst();
+    return Number(result.numDeletedRows);
+  }
+
   /**
    * Delete all results for an event
    */

--- a/packages/server/src/services/IngestService.ts
+++ b/packages/server/src/services/IngestService.ts
@@ -159,10 +159,21 @@ export class IngestService {
       imported.results = parsed.results.length;
       lap(`importResults (${parsed.results.length})`);
 
-      // 7. Set has_xml_data flag (enables JSON/TCP ingestion)
+      // 7. C123 XML is a full event snapshot, so absence means deletion.
+      // Without this pass, dropping a competitor leaves stale rows on clients.
+      await this.pruneStale(event.id, parsed, raceIdMap, participantIdMap, {
+        classRepo: txClassRepo,
+        participantRepo: txParticipantRepo,
+        raceRepo: txRaceRepo,
+        resultRepo: txResultRepo,
+        courseRepo: txCourseRepo,
+      });
+      lap('pruneStale');
+
+      // 8. Set has_xml_data flag (enables JSON/TCP ingestion)
       await txEventRepo.setHasXmlData(event.id);
 
-      // 8. Log successful ingestion
+      // 9. Log successful ingestion
       const totalItems =
         imported.classes +
         imported.participants +
@@ -352,6 +363,62 @@ export class IngestService {
         qualified: result.qualified,
       });
     }
+  }
+
+  // Order matters: per-race result pruning runs before race deletion so it
+  // only touches races still in the XML; race/participant deletion then
+  // cascades any remaining stale results.
+  private async pruneStale(
+    eventId: number,
+    parsed: ParsedC123Data,
+    raceIdMap: Map<string, number>,
+    participantIdMap: Map<string, number>,
+    repos: {
+      classRepo: ClassRepository;
+      participantRepo: ParticipantRepository;
+      raceRepo: RaceRepository;
+      resultRepo: ResultRepository;
+      courseRepo: CourseRepository;
+    }
+  ): Promise<void> {
+    const xmlResultsByRace = new Map<string, Set<string>>();
+    for (const r of parsed.results) {
+      const set = xmlResultsByRace.get(r.raceId) ?? new Set<string>();
+      set.add(r.participantId);
+      xmlResultsByRace.set(r.raceId, set);
+    }
+
+    for (const race of parsed.races) {
+      const raceDbId = raceIdMap.get(race.raceId);
+      if (raceDbId === undefined) continue;
+      const keepParticipants = xmlResultsByRace.get(race.raceId) ?? new Set<string>();
+      const keepDbIds: number[] = [];
+      for (const pid of keepParticipants) {
+        const pDbId = participantIdMap.get(pid);
+        if (pDbId !== undefined) keepDbIds.push(pDbId);
+      }
+      await repos.resultRepo.deleteByRaceIdNotInParticipants(raceDbId, keepDbIds);
+    }
+
+    await repos.raceRepo.deleteByEventIdNotIn(
+      eventId,
+      parsed.races.map((r) => r.raceId)
+    );
+
+    await repos.participantRepo.deleteByEventIdNotIn(
+      eventId,
+      parsed.participants.map((p) => p.participantId)
+    );
+
+    await repos.classRepo.deleteByEventIdNotIn(
+      eventId,
+      parsed.classes.map((c) => c.classId)
+    );
+
+    await repos.courseRepo.deleteByEventIdNotIn(
+      eventId,
+      parsed.courses.map((c) => c.courseNr)
+    );
   }
 
   /**

--- a/packages/server/tests/integration/ingest-cleanup.test.ts
+++ b/packages/server/tests/integration/ingest-cleanup.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Kysely, SqliteDialect, Migrator, type MigrationProvider } from 'kysely';
+import Database from 'better-sqlite3';
+import type { Database as DatabaseSchema } from '../../src/db/schema.js';
+import { IngestService } from '../../src/services/IngestService.js';
+
+import * as m001 from '../../src/db/migrations/001_create_events.js';
+import * as m002 from '../../src/db/migrations/002_create_classes.js';
+import * as m003 from '../../src/db/migrations/003_create_participants.js';
+import * as m004 from '../../src/db/migrations/004_create_races.js';
+import * as m005 from '../../src/db/migrations/005_create_results.js';
+import * as m006 from '../../src/db/migrations/006_create_courses.js';
+import * as m007 from '../../src/db/migrations/007_create_indexes.js';
+import * as m008 from '../../src/db/migrations/008_add_event_config.js';
+import * as m009 from '../../src/db/migrations/009_create_ingest_records.js';
+import * as m010 from '../../src/db/migrations/010_data_abstraction.js';
+import * as m011 from '../../src/db/migrations/011_remove_legacy_columns.js';
+import * as m012 from '../../src/db/migrations/012_add_status_changed_at.js';
+import * as m013 from '../../src/db/migrations/013_add_event_image.js';
+
+const inMemoryMigrationProvider: MigrationProvider = {
+  async getMigrations() {
+    return {
+      '001_create_events': m001,
+      '002_create_classes': m002,
+      '003_create_participants': m003,
+      '004_create_races': m004,
+      '005_create_results': m005,
+      '006_create_courses': m006,
+      '007_create_indexes': m007,
+      '008_add_event_config': m008,
+      '009_create_ingest_records': m009,
+      '010_data_abstraction': m010,
+      '011_remove_legacy_columns': m011,
+      '012_add_status_changed_at': m012,
+      '013_add_event_image': m013,
+    };
+  },
+};
+
+/**
+ * Build a minimal-but-valid C123 XML payload for testing.
+ *
+ * - participants: list of {id, family} entries (all in class K1M)
+ * - resultParticipantIds: which participants appear in race R1's results
+ *   (subset of participants — empty means no results yet)
+ */
+function buildXml(opts: {
+  participants: Array<{ id: string; family: string }>;
+  resultParticipantIds: string[];
+  raceIds?: string[];
+}): string {
+  const raceIds = opts.raceIds ?? ['R1'];
+  const participantTags = opts.participants
+    .map(
+      (p) =>
+        `<Participants><Id>${p.id}</Id><ClassId>K1M</ClassId><FamilyName>${p.family}</FamilyName></Participants>`
+    )
+    .join('\n');
+  const scheduleTags = raceIds
+    .map(
+      (rid) =>
+        `<Schedule><RaceId>${rid}</RaceId><ClassId>K1M</ClassId><DisId>BR1</DisId></Schedule>`
+    )
+    .join('\n');
+  const resultTags = opts.resultParticipantIds
+    .map(
+      (pid, i) =>
+        `<Results><RaceId>R1</RaceId><Id>${pid}</Id><Bib>${i + 1}</Bib></Results>`
+    )
+    .join('\n');
+
+  return `<?xml version="1.0"?>
+<Canoe123Data>
+  <Events>
+    <EventId>EV1</EventId>
+    <MainTitle>Test Event</MainTitle>
+  </Events>
+  <Classes>
+    <ClassId>K1M</ClassId>
+    <Class>K1M</Class>
+  </Classes>
+  ${participantTags}
+  ${scheduleTags}
+  ${resultTags}
+</Canoe123Data>`;
+}
+
+async function setupTestDb(): Promise<{
+  db: Kysely<DatabaseSchema>;
+  close: () => Promise<void>;
+}> {
+  const sqlite = new Database(':memory:');
+  sqlite.pragma('foreign_keys = ON');
+  const dialect = new SqliteDialect({ database: sqlite });
+  const db = new Kysely<DatabaseSchema>({ dialect });
+
+  const migrator = new Migrator({ db, provider: inMemoryMigrationProvider });
+
+  const { error, results } = await migrator.migrateToLatest();
+  if (error) {
+    throw new Error(`Migration failed: ${String(error)}`);
+  }
+  if (results?.some((r) => r.status === 'Error')) {
+    throw new Error('Some migrations failed');
+  }
+
+  return { db, close: () => db.destroy() };
+}
+
+const TEST_API_KEY = 'test-key-156';
+
+async function seedEvent(db: Kysely<DatabaseSchema>): Promise<number> {
+  const result = await db
+    .insertInto('events')
+    .values({
+      event_id: 'EV1',
+      main_title: 'Test Event',
+      status: 'startlist',
+      api_key: TEST_API_KEY,
+      has_xml_data: 0,
+    })
+    .executeTakeFirstOrThrow();
+  return Number(result.insertId);
+}
+
+describe('Ingest cleanup of stale records (#156)', () => {
+  let db: Kysely<DatabaseSchema>;
+  let close: () => Promise<void>;
+  let ingestService: IngestService;
+  let eventDbId: number;
+
+  beforeEach(async () => {
+    ({ db, close } = await setupTestDb());
+    eventDbId = await seedEvent(db);
+    ingestService = new IngestService(db);
+  });
+
+  afterEach(async () => {
+    await close();
+  });
+
+  it('removes a competitor that was dropped from a race in the new XML', async () => {
+    // First push: race R1 has competitors 1, 2, 3
+    await ingestService.ingestXml(
+      buildXml({
+        participants: [
+          { id: '1', family: 'Alpha' },
+          { id: '2', family: 'Beta' },
+          { id: '3', family: 'Gamma' },
+        ],
+        resultParticipantIds: ['1', '2', '3'],
+      }),
+      TEST_API_KEY
+    );
+
+    const beforeResults = await db
+      .selectFrom('results')
+      .selectAll()
+      .where('event_id', '=', eventDbId)
+      .execute();
+    expect(beforeResults).toHaveLength(3);
+
+    // Second push: race R1 now has only competitors 1, 2 (3 was removed from race)
+    // Participant 3 still exists in event roster.
+    await ingestService.ingestXml(
+      buildXml({
+        participants: [
+          { id: '1', family: 'Alpha' },
+          { id: '2', family: 'Beta' },
+          { id: '3', family: 'Gamma' },
+        ],
+        resultParticipantIds: ['1', '2'],
+      }),
+      TEST_API_KEY
+    );
+
+    const afterResults = await db
+      .selectFrom('results')
+      .innerJoin('participants', 'participants.id', 'results.participant_id')
+      .select(['participants.participant_id'])
+      .where('results.event_id', '=', eventDbId)
+      .execute();
+
+    expect(afterResults.map((r) => r.participant_id).sort()).toEqual(['1', '2']);
+  });
+
+  it('removes a participant entirely when dropped from event roster', async () => {
+    await ingestService.ingestXml(
+      buildXml({
+        participants: [
+          { id: '1', family: 'Alpha' },
+          { id: '2', family: 'Beta' },
+        ],
+        resultParticipantIds: ['1', '2'],
+      }),
+      TEST_API_KEY
+    );
+
+    // Second push: participant 2 entirely removed from event
+    await ingestService.ingestXml(
+      buildXml({
+        participants: [{ id: '1', family: 'Alpha' }],
+        resultParticipantIds: ['1'],
+      }),
+      TEST_API_KEY
+    );
+
+    const participants = await db
+      .selectFrom('participants')
+      .select(['participant_id'])
+      .where('event_id', '=', eventDbId)
+      .execute();
+    expect(participants.map((p) => p.participant_id)).toEqual(['1']);
+
+    // Their results should be cascade-deleted
+    const results = await db
+      .selectFrom('results')
+      .selectAll()
+      .where('event_id', '=', eventDbId)
+      .execute();
+    expect(results).toHaveLength(1);
+  });
+
+  it('removes a race entirely when dropped from schedule', async () => {
+    await ingestService.ingestXml(
+      buildXml({
+        participants: [{ id: '1', family: 'Alpha' }],
+        resultParticipantIds: ['1'],
+        raceIds: ['R1', 'R2'],
+      }),
+      TEST_API_KEY
+    );
+
+    const beforeRaces = await db
+      .selectFrom('races')
+      .select(['race_id'])
+      .where('event_id', '=', eventDbId)
+      .execute();
+    expect(beforeRaces.map((r) => r.race_id).sort()).toEqual(['R1', 'R2']);
+
+    // R2 dropped from schedule
+    await ingestService.ingestXml(
+      buildXml({
+        participants: [{ id: '1', family: 'Alpha' }],
+        resultParticipantIds: ['1'],
+        raceIds: ['R1'],
+      }),
+      TEST_API_KEY
+    );
+
+    const afterRaces = await db
+      .selectFrom('races')
+      .select(['race_id'])
+      .where('event_id', '=', eventDbId)
+      .execute();
+    expect(afterRaces.map((r) => r.race_id)).toEqual(['R1']);
+  });
+});


### PR DESCRIPTION
## Summary
- After upsert phase, `IngestService.ingestXml` now deletes records absent from the new XML snapshot — competitors dropped from a race, races removed from the schedule, and obsolete classes/participants/courses.
- Adds `deleteByEventIdNotIn` (Class/Participant/Race/CourseRepository) and `deleteByRaceIdNotInParticipants` (ResultRepository). Empty keep-list ⇒ delete all (handles legitimately empty results/courses sections).
- Pruning runs inside the existing ingest transaction; FK `ON DELETE CASCADE` handles dependent results when a race or participant is removed.

## Test plan
- [x] New integration test `ingest-cleanup.test.ts` covers three scenarios: competitor dropped from race, participant removed from event, race removed from schedule. All pass.
- [x] Full server test suite (`npx vitest run` in `packages/server`): 141 pass, 2 skipped, 0 fail.
- [x] `npm run typecheck` clean for both server and client.
- [ ] Smoke test on staging: push two XML versions of the same event, second with one competitor removed, verify they disappear from `/api/v1/events/:id/results/:raceId` and from the live UI.

Closes #156