### PR TITLE
build: pin @types/react at workspace root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@vitest/ui": "^4.1.7",
         "concurrently": "^9.1.2",
         "jsdom": "^29.1.1",
@@ -1823,6 +1825,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/ws": {
@@ -5516,40 +5538,6 @@
       "version": "0.12.4",
       "devDependencies": {
         "typescript": "^5.7.3"
-      }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,23 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui"
   },
+  "//devDependencies": [
+    "Rationale: @types/react and @types/react-dom are declared HERE, at the workspace",
+    "root, even though only packages/client renders React.",
+    "wouter is hoisted to the root node_modules, and its .d.ts imports from \"react\".",
+    "Node type resolution walks up from node_modules/wouter/, so it only ever consults",
+    "the ROOT @types/react — it never sees packages/client/node_modules/@types/react.",
+    "With no root copy, wouter Route generics silently degrade to any and the client",
+    "build fails with TS7006 on the <Route>{(params) => ...}</Route> blocks in App.tsx.",
+    "Until this was pinned the build passed only by accident: @testing-library/react has",
+    "an optional peer on @types/react, which happened to hoist @types/react@18 to the root.",
+    "Any lockfile regeneration that pruned it (e.g. the vitest 4.1.9 bump, PR #220) broke",
+    "the build. Declaring it explicitly makes root placement guaranteed, not incidental.",
+    "Keep the major in sync with packages/client (React 19)."
+  ],
   "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@vitest/ui": "^4.1.7",
     "concurrently": "^9.1.2",
     "jsdom": "^29.1.1",


### PR DESCRIPTION
## Problem

Three dependabot PRs are red with the same error, and none of them touch React:

- #220 `vitest` 4.1.7 → 4.1.9
- #225 `@vitest/ui` 4.1.7 → 4.1.9
- #224 `tsx` 4.22.3 → 4.22.4

```
src/App.tsx(45,15): error TS7006: Parameter 'params' implicitly has an 'any' type.
src/App.tsx(53,15): error TS7006: Parameter 'params' implicitly has an 'any' type.
```

## Root cause

`wouter` is hoisted to the **root** `node_modules`, and its `.d.ts` imports from `"react"`. Node type resolution walks up from `node_modules/wouter/`, so it only ever consults the **root** `@types/react` — it never sees `packages/client/node_modules/@types/react`. With no root copy, wouter's `Route` generics degrade to `any`, and `noImplicitAny` rejects the `<Route>{(params) => ...}</Route>` blocks in `App.tsx`.

Until now the build passed **by accident**: `@testing-library/react` declares an optional peer on `@types/react`, which happened to hoist `@types/react@18.3.28` to the root. Any lockfile regeneration that pruned that stray entry broke the client build — which is exactly what those three dependabot lockfiles do.

Reproduced on `main` (green), then by deleting only `node_modules/@types/react` (red with the exact TS7006 pair), then by restoring it as React **19** types (green again) — so this is about *presence at the root*, not about the 18-vs-19 major.

## Fix

Declare `@types/react` / `@types/react-dom` as root devDependencies, so root placement is guaranteed rather than incidental. Types only — no runtime impact, no bump (`build:`).

The `//devDependencies` note follows the existing `//overrides` convention so the next person doesn't "clean up" what looks like a stray dependency.

## Verification (local, Node 20.20.2)

| Check | Result |
|---|---|
| vite singleton guard | `vite@7.1.12`, single version ✅ |
| `node_modules/rolldown` absent | ✅ |
| `npm run build` | clean ✅ |
| `npm test` | 24 files, 243 passed / 2 skipped ✅ |
| same, with #220 + #225 + #224 applied on top | build clean, 243 passed ✅ |

Unblocks #220, #225 and #224.